### PR TITLE
Build lib with -fPIC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,10 @@ target_include_directories(rsl PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>
 )
+set_property(
+  TARGET rsl
+  PROPERTY POSITION_INDEPENDENT_CODE ON
+)
 
 install(
   DIRECTORY include/


### PR DESCRIPTION
This is useful for users who have a SHARED library they are building that depends on this.