### PR TITLE
Find Catch2 via find_package

### DIFF
--- a/cmake/FindCatch2.cmake
+++ b/cmake/FindCatch2.cmake
@@ -1,0 +1,10 @@
+include(FetchContent)
+
+set(CATCH_INSTALL_DOCS OFF)
+set(CATCH_INSTALL_EXTRAS OFF)
+FetchContent_Declare(Catch2
+    GIT_REPOSITORY https://github.com/catchorg/Catch2.git
+    GIT_TAG v${Catch2_FIND_VERSION})
+FetchContent_MakeAvailable(Catch2)
+set_target_properties(Catch2 PROPERTIES COMPILE_OPTIONS "")
+include(Catch)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,13 +1,6 @@
-include(FetchContent)
+list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 
-set(CATCH_INSTALL_DOCS OFF)
-set(CATCH_INSTALL_EXTRAS OFF)
-FetchContent_Declare(Catch2
-    GIT_REPOSITORY https://github.com/catchorg/Catch2.git
-    GIT_TAG v3.1.0)
-FetchContent_MakeAvailable(Catch2)
-set_target_properties(Catch2 PROPERTIES COMPILE_OPTIONS "")
-include(Catch)
+find_package(Catch2 3.1.0 REQUIRED)
 
 add_executable(test-rand rand.cpp)
 target_link_libraries(test-rand PRIVATE rsl::rsl Catch2::Catch2WithMain)


### PR DESCRIPTION
`find_package` is the canonical way to express dependencies in CMake and conveniently provides a mechanism for override the default package search logic by simply providing your own Find<Package>.cmake file. This means when it comes time to use a system install of Catch2, we can just delete this custom module.

This also has the benefit of providing a neatly contained CMake module that others can paste into their projects if need be to avoid them having to write all this code themselves.