### PR TITLE
operator| for plain old values

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -18,6 +18,8 @@
   <depend>eigen</depend>
   <depend>tl_expected</depend>
 
+  <test_depend>range-v3</test_depend>
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,6 +1,7 @@
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 
 find_package(Catch2 3.1.0 REQUIRED)
+find_package(range-v3 0.11.0 REQUIRED)
 
 add_executable(test-rsl
     monad.cpp
@@ -9,5 +10,9 @@ add_executable(test-rsl
     queue.cpp
     random.cpp
     try.cpp)
-target_link_libraries(test-rsl PRIVATE rsl::rsl Catch2::Catch2WithMain)
+target_link_libraries(test-rsl PRIVATE
+    rsl::rsl
+    Catch2::Catch2WithMain
+    range-v3::range-v3
+)
 catch_discover_tests(test-rsl)


### PR DESCRIPTION
Signed-off-by: Tyler Weaver <tyler@picknik.ai>

This includes tests for operator| used to monadic bind with expected types a test to verify this does not conflict with the operator| from range-v3.