### PR TITLE
Add `rsl::Queue`

### DIFF
--- a/include/rsl/queue.hpp
+++ b/include/rsl/queue.hpp
@@ -1,0 +1,78 @@
+#pragma once
+
+#include <chrono>
+#include <condition_variable>
+#include <mutex>
+#include <optional>
+#include <queue>
+
+namespace rsl {
+
+/**
+ * @brief Thread-safe queue. Particularly useful when multiple threads need to write to and/or read
+ * from a queue.
+ */
+template <typename T>
+class Queue {
+   public:
+    /**
+     * @brief Get the size of the queue
+     * @return Queue size
+     */
+    [[nodiscard]] auto size() const noexcept {
+        auto const lock = std::lock_guard(mutex_);
+        return queue_.size();
+    }
+
+    /**
+     * @brief Check if the queue is empty
+     * @return True if the queue is empty, otherwise false
+     */
+    [[nodiscard]] auto empty() const noexcept {
+        auto const lock = std::lock_guard(mutex_);
+        return queue_.empty();
+    }
+
+    /**
+     * @brief Push data into the queue
+     * @param[in] value Data to push into the queue
+     */
+    void push(T value) noexcept {
+        auto const lock = std::lock_guard(mutex_);
+        queue_.push(std::move(value));
+        cv_.notify_one();
+    }
+
+    /**
+     * @brief Clear the queue
+     */
+    void clear() noexcept {
+        auto const lock = std::lock_guard(mutex_);
+
+        // Swap queue with an empty queue of the same type to ensure queue_ is left in a
+        // default-constructed state
+        decltype(queue_)().swap(queue_);
+    }
+
+    /**
+     * @brief Wait for given duration then pop from the queue and return the element
+     * @param[in] wait_time Maximum time to wait for queue to be non-empty
+     * @return Data popped from the queue or error
+     */
+    [[nodiscard]] auto pop(std::chrono::nanoseconds wait_time = {}) -> std::optional<T> {
+        auto lock = std::unique_lock(mutex_);
+
+        // If queue is empty after wait_time, return nothing
+        if (!cv_.wait_for(lock, wait_time, [this] { return !queue_.empty(); })) return std::nullopt;
+
+        auto value = queue_.front();
+        queue_.pop();
+        return value;
+    }
+
+   private:
+    std::queue<T> queue_;
+    std::condition_variable cv_;
+    mutable std::mutex mutex_;
+};
+}  // namespace rsl

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6,6 +6,7 @@ add_executable(test-rsl
     monad.cpp
     no_discard.cpp
     overload.cpp
+    queue.cpp
     rand.cpp
     try.cpp)
 target_link_libraries(test-rsl PRIVATE rsl::rsl Catch2::Catch2WithMain)

--- a/tests/queue.cpp
+++ b/tests/queue.cpp
@@ -1,0 +1,90 @@
+#include <rsl/queue.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <atomic>
+#include <thread>
+#include <type_traits>
+
+using namespace std::chrono_literals;
+
+static_assert(!std::is_copy_constructible_v<rsl::Queue<int>>);
+static_assert(!std::is_copy_assignable_v<rsl::Queue<int>>);
+static_assert(!std::is_nothrow_move_constructible_v<rsl::Queue<int>>);
+static_assert(!std::is_nothrow_move_assignable_v<rsl::Queue<int>>);
+
+TEST_CASE("rsl::Queue") {
+    SECTION("Default constructor") {
+        auto const queue = rsl::Queue<int>();
+        CHECK(queue.size() == 0);
+        CHECK(queue.empty());
+    }
+
+    SECTION("push()") {
+        auto queue = rsl::Queue<int>();
+        queue.push(42);
+        CHECK(queue.size() == 1);
+        CHECK(!queue.empty());
+
+        for (int i = 0; i < 99; ++i) queue.push(i);
+        CHECK(queue.size() == 100);
+        CHECK(!queue.empty());
+    }
+
+    SECTION("clear()") {
+        auto queue = rsl::Queue<int>();
+        for (int i = 0; i < 100; ++i) queue.push(i);
+        CHECK(queue.size() == 100);
+        CHECK(!queue.empty());
+        queue.clear();
+        CHECK(queue.size() == 0);
+        CHECK(queue.empty());
+    }
+
+    SECTION("pop()") {
+        SECTION("Sequentially") {
+            auto queue = rsl::Queue<int>();
+
+            CHECK(!queue.pop().has_value());
+            queue.push(999);
+            queue.push(1000);
+
+            CHECK(queue.pop(-1ms).value() == 999);
+            CHECK(queue.size() == 1);
+
+            CHECK(queue.pop().value() == 1000);
+            CHECK(queue.size() == 0);
+
+            CHECK(!queue.pop(1ms).has_value());
+            CHECK(queue.size() == 0);
+        }
+
+        SECTION("Concurrently") {
+            auto queue = rsl::Queue<int>();
+
+            constexpr auto thread_count = size_t(10);
+            constexpr auto item_count = size_t(100);
+
+            auto producers = std::array<std::thread, thread_count>();
+            for (auto& producer : producers) {
+                producer = std::thread([&queue] {
+                    for (size_t i = 0; i < item_count; ++i) queue.push(int(i));
+                });
+            }
+
+            auto items_removed = std::atomic<size_t>(0);
+            auto consumers = std::array<std::thread, thread_count>();
+            for (auto& consumer : consumers) {
+                consumer = std::thread([&queue, &items_removed] {
+                    for (size_t i = 0; i < item_count; ++i)
+                        if (queue.pop(1ms).has_value()) ++items_removed;
+                });
+            }
+
+            for (auto& producer : producers) producer.join();
+            for (auto& consumer : consumers) consumer.join();
+
+            CHECK(queue.size() == thread_count * item_count - items_removed);
+        }
+    }
+}


### PR DESCRIPTION
Implements a thread-safe queue. Particularly useful when multiple threads need to read from and/or write to a queue.