### PR TITLE
Add build system support for generating documentation

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,0 +1,40 @@
+name: Docs
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  docs:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    container: ghcr.io/picknikrobotics/rsl:upstream-rolling
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v3
+      - name: Setup Pages
+        uses: actions/configure-pages@v2
+      - name: Source ROS
+        run: |
+          . /opt/ros/rolling/setup.sh
+          echo "$(env)" >> $GITHUB_ENV
+      - name: Configure
+        run: cmake -B build
+      - name: Build Doxygen Site
+        run: cmake --build build --target docs
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: build/docs/html
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.22)
-project(rsl VERSION 0.0.0 LANGUAGES CXX)
+project(rsl VERSION 0.1.1 LANGUAGES CXX)
 
 set(CMAKE_CXX_EXTENSIONS ON)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.22)
-project(rsl VERSION 0.1.1 LANGUAGES CXX)
+project(rsl VERSION 0.1.1 LANGUAGES CXX DESCRIPTION "ROS Support Library")
 
 set(CMAKE_CXX_EXTENSIONS ON)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,8 @@ target_include_directories(rsl PUBLIC
 )
 target_link_libraries(rsl PUBLIC Eigen3::Eigen tl_expected::tl_expected)
 
+add_subdirectory(docs)
+
 if(BUILD_TESTING)
     add_subdirectory(tests)
 endif()

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -1,0 +1,4 @@
+find_package(Doxygen REQUIRED)
+
+set(DOXYGEN_GENERATE_TREEVIEW TRUE)
+doxygen_add_docs(docs ${PROJECT_SOURCE_DIR}/include)

--- a/include/rsl/monad.hpp
+++ b/include/rsl/monad.hpp
@@ -6,6 +6,8 @@
 
 namespace rsl {
 
+/** @file */
+
 /**
  * @brief Monad optional bind
  *

--- a/include/rsl/monad.hpp
+++ b/include/rsl/monad.hpp
@@ -7,15 +7,15 @@
 namespace rsl {
 
 /**
- * @brief      Monad optional bind
+ * @brief Monad optional bind
  *
- * @param[in]  opt   The input optional
- * @param[in]  fn    The function, must return a optional
+ * @param opt Input optional
+ * @param fn  Function, must return a optional
  *
- * @tparam     T     The input type
- * @tparam     Fn    The function
+ * @tparam T  Input type
+ * @tparam Fn Function
  *
- * @return     Return type of fn
+ * @return Return type of fn
  */
 template <typename T, typename Fn>
 [[nodiscard]] constexpr auto mbind(std::optional<T> const& opt, Fn fn)
@@ -27,16 +27,16 @@ template <typename T, typename Fn>
 }
 
 /**
- * @brief      Monad tl::expected<T,E>
+ * @brief Monad tl::expected<T,E>
  *
- * @param[in]  exp   The tl::expected<T,E> input
- * @param[in]  fn    The function to apply
+ * @param exp tl::expected<T,E> input
+ * @param fn  Function to apply
  *
- * @tparam     T     The type for the input expected
- * @tparam     E     The error type
- * @tparam     Fn    The function
+ * @tparam T  Type for the input expected
+ * @tparam E  Error type
+ * @tparam Fn Function
  *
- * @return     The return type of the function
+ * @return Return type of the function
  */
 template <typename T, typename E, typename Fn>
 [[nodiscard]] constexpr auto mbind(tl::expected<T, E> const& exp, Fn fn)
@@ -46,14 +46,14 @@ template <typename T, typename E, typename Fn>
 }
 
 /**
- * @brief      Monadic try, used to lift a function that throws an
- * exception one that returns an tl::expected<T, std::exception_ptr>
+ * @brief Monadic try, used to lift a function that throws an exception into one that returns an
+ * tl::expected<T, std::exception_ptr>
  *
- * @param[in]  fn    The function to call
+ * @param fn Function to call
  *
- * @tparam     Fn    The function type
+ * @tparam Fn Function type
  *
- * @return     The return value of the function
+ * @return Return value of the function
  */
 template <typename Fn>
 [[nodiscard]] auto mtry(Fn fn) -> tl::expected<std::invoke_result_t<Fn>, std::exception_ptr> try {
@@ -63,15 +63,15 @@ template <typename Fn>
 }
 
 /**
- * @brief      Monadic compose two monad functions
+ * @brief Monadic compose two monad functions
  *
- * @param[in]  fn    The first function
- * @param[in]  g     The second function
+ * @param fn First function
+ * @param g  Second function
  *
- * @tparam     Fn    The type of the first function
- * @tparam     G     The type of the second function
+ * @tparam Fn Type of the first function
+ * @tparam G  Type of the second function
  *
- * @return     A functional composition of two monad functions
+ * @return A functional composition of two monad functions
  */
 template <typename Fn, typename G>
 [[nodiscard]] constexpr auto mcompose(Fn fn, G g) {
@@ -79,30 +79,30 @@ template <typename Fn, typename G>
 }
 
 /**
- * @brief      Variadic mcompose
+ * @brief Variadic mcompose
  *
- * @param[in]  t      The first function
- * @param[in]  g      The second function
- * @param[in]  vars   The rest of the functions
+ * @param t    First function
+ * @param g    Second function
+ * @param vars Rest of the functions
  *
- * @tparam     T      The type of the first function
- * @tparam     G      The type of the second function
- * @tparam     Types  The types of the rest of the functions
+ * @tparam T  Type of the first function
+ * @tparam G  Type of the second function
+ * @tparam Ts Types of the rest of the functions
  *
- * @return     A functional composition of variadic monad functions
+ * @return A functional composition of variadic monad functions
  */
-template <typename T, typename G, typename... Types>
-[[nodiscard]] constexpr auto mcompose(T t, G g, Types... vars) {
+template <typename T, typename G, typename... Ts>
+[[nodiscard]] constexpr auto mcompose(T t, G g, Ts... vars) {
     auto exp = mcompose(t, g);
     return mcompose(exp, vars...);
 }
 
 /**
- * @brief           Test if expected type is Error
+ * @brief Test if expected type is Error
  *
- * @param[in] exp   The input tl::expected<T,E> value
+ * @param exp Input tl::expected<T,E> value
  *
- * @return          True if expected paraemter is Error
+ * @return True if expected paraemter is Error
  */
 template <typename T, typename E>
 [[nodiscard]] constexpr auto has_error(tl::expected<T, E> const& exp) {
@@ -110,11 +110,11 @@ template <typename T, typename E>
 }
 
 /**
- * @brief           Test if expected type is Value
+ * @brief Test if expected type is Value
  *
- * @param[in] exp   The input tl::expected<T,E> value
+ * @param exp Input tl::expected<T,E> value
  *
- * @return          True if expected paraemter is Value
+ * @return True if expected paraemter is Value
  */
 template <typename T, typename E>
 [[nodiscard]] constexpr auto has_value(tl::expected<T, E> const& exp) {
@@ -131,15 +131,15 @@ constexpr bool is_optional = is_optional_impl<std::remove_cv_t<std::remove_refer
 }  // namespace rsl
 
 /**
- * @brief      Overload of the | operator as bind
+ * @brief Overload of the | operator as bind
  *
- * @param[in]  opt   The input optional
- * @param[in]  f     The function
+ * @param opt Input optional
+ * @param f   Function
  *
- * @tparam     T     The input type
- * @tparam     Fn     The function
+ * @tparam T  Input type
+ * @tparam Fn Function
  *
- * @return     Return type of f
+ * @return Return type of f
  */
 template <typename T, typename Fn, typename = std::enable_if_t<rsl::is_optional<T>>,
           typename = std::enable_if_t<std::is_invocable_v<
@@ -149,16 +149,16 @@ template <typename T, typename Fn, typename = std::enable_if_t<rsl::is_optional<
 }
 
 /**
- * @brief      Overload of the | operator as bind
+ * @brief Overload of the | operator as bind
  *
- * @param[in]  exp   The input tl::expected<T,E> value
- * @param[in]  fn    The function to apply
+ * @param exp Input tl::expected<T,E> value
+ * @param fn  Function to apply
  *
- * @tparam     T     The type for the input expected
- * @tparam     E     The error type
- * @tparam     Fn    The function
+ * @tparam T  Type for the input expected
+ * @tparam E  Error type
+ * @tparam Fn Function
  *
- * @return     Return type of fn
+ * @return Return type of fn
  */
 template <typename T, typename E, typename Fn>
 [[nodiscard]] constexpr auto operator|(tl::expected<T, E> const& exp, Fn fn) {
@@ -166,15 +166,15 @@ template <typename T, typename E, typename Fn>
 }
 
 /**
- * @brief      Overload of the | operator for unary functions
+ * @brief Overload of the | operator for unary functions
  *
- * @param[in]  val   The input value
- * @param[in]  fn    The function to apply on val
+ * @param val Input value
+ * @param fn  Function to apply on val
  *
- * @tparam     T     The type for the input
- * @tparam     Fn    The function
+ * @tparam T  Type for the input
+ * @tparam Fn Function
  *
- * @return     Return the result of invoking the function on val
+ * @return Return the result of invoking the function on val
  */
 template <typename T, typename Fn, typename = std::enable_if_t<!rsl::is_optional<T>>>
 [[nodiscard]] constexpr auto operator|(T&& val, Fn&& fn) ->

--- a/include/rsl/no_discard.hpp
+++ b/include/rsl/no_discard.hpp
@@ -8,8 +8,6 @@ namespace rsl {
  * @brief      Template for creating lambdas with the nodiscard attribute
  *
  * @tparam     Fn The lambda
- *
- * @example    no_discard.cpp
  */
 template <typename Fn>
 struct NoDiscard {

--- a/include/rsl/no_discard.hpp
+++ b/include/rsl/no_discard.hpp
@@ -4,6 +4,8 @@
 
 namespace rsl {
 
+/** @file */
+
 /**
  * @brief Template for creating lambdas with the nodiscard attribute
  *

--- a/include/rsl/no_discard.hpp
+++ b/include/rsl/no_discard.hpp
@@ -5,9 +5,9 @@
 namespace rsl {
 
 /**
- * @brief      Template for creating lambdas with the nodiscard attribute
+ * @brief Template for creating lambdas with the nodiscard attribute
  *
- * @tparam     Fn The lambda
+ * @tparam Fn  Lambda
  */
 template <typename Fn>
 struct NoDiscard {

--- a/include/rsl/overload.hpp
+++ b/include/rsl/overload.hpp
@@ -2,6 +2,8 @@
 
 namespace rsl {
 
+/** @file */
+
 /**
  * @brief Class template for creating overloads sets to use with std::visit
  *

--- a/include/rsl/overload.hpp
+++ b/include/rsl/overload.hpp
@@ -2,6 +2,11 @@
 
 namespace rsl {
 
+/**
+ * @brief Class template for creating overloads sets to use with std::visit
+ *
+ * @tparam Ts Types
+ */
 template <typename... Ts>
 struct Overload : Ts... {
     using Ts::operator()...;

--- a/include/rsl/queue.hpp
+++ b/include/rsl/queue.hpp
@@ -8,6 +8,8 @@
 
 namespace rsl {
 
+/** @file */
+
 /**
  * @brief Thread-safe queue. Particularly useful when multiple threads need to write to and/or read
  * from a queue.

--- a/include/rsl/queue.hpp
+++ b/include/rsl/queue.hpp
@@ -35,7 +35,7 @@ class Queue {
 
     /**
      * @brief Push data into the queue
-     * @param[in] value Data to push into the queue
+     * @param value Data to push into the queue
      */
     void push(T value) noexcept {
         auto const lock = std::lock_guard(mutex_);
@@ -56,7 +56,7 @@ class Queue {
 
     /**
      * @brief Wait for given duration then pop from the queue and return the element
-     * @param[in] wait_time Maximum time to wait for queue to be non-empty
+     * @param wait_time Maximum time to wait for queue to be non-empty
      * @return Data popped from the queue or error
      */
     [[nodiscard]] auto pop(std::chrono::nanoseconds wait_time = {}) -> std::optional<T> {

--- a/include/rsl/random.hpp
+++ b/include/rsl/random.hpp
@@ -7,6 +7,8 @@
 
 namespace rsl {
 
+/** @file */
+
 /**
  * @brief Get a random number generator
  *

--- a/include/rsl/random.hpp
+++ b/include/rsl/random.hpp
@@ -16,7 +16,7 @@ namespace rsl {
  * sequence is provided this function throws. The returned value is a reference to a thread_local
  * static generator.
  *
- * @param[in] seed_sequence Seed sequence for random number generator
+ * @param seed_sequence Seed sequence for random number generator
  *
  * @return Seeded random number generator
  */
@@ -25,8 +25,8 @@ auto rng(std::seed_seq seed_sequence = {}) -> std::mt19937&;
 /**
  * @brief Get a uniform real number in a given range
  *
- * @param[in] lower Lower bound, inclusive
- * @param[in] upper Upper bound, exclusive
+ * @param lower Lower bound, inclusive
+ * @param upper Upper bound, exclusive
  *
  * @tparam RealType Floating point type
  *
@@ -42,8 +42,8 @@ auto uniform_real(RealType lower, RealType upper) {
 /**
  * @brief Get a uniform integer number in a given range
  *
- * @param[in] lower Lower bound, inclusive
- * @param[in] upper Upper bound, inclusive
+ * @param lower Lower bound, inclusive
+ * @param upper Upper bound, inclusive
  *
  * @tparam IntType Integral type
  *

--- a/include/rsl/try.hpp
+++ b/include/rsl/try.hpp
@@ -2,6 +2,8 @@
 
 #include <tl_expected/expected.hpp>
 
+/** @file */
+
 /**
  * @brief Unwrap an expected into a stack variable or return the unexpected value
  *

--- a/include/rsl/try.hpp
+++ b/include/rsl/try.hpp
@@ -2,21 +2,29 @@
 
 #include <tl_expected/expected.hpp>
 
-// This macro requires the use of non-standard C++. Compiler extensions must be enabled and
-// -Wpedantic cannot be used. With GCC and Clang, you can disable -Wpedantic for an entire
-// translation unit like this:
-//
-// #pragma GCC diagnostic ignored "-Wpedantic"
-//
-// You can disable -Wpedantic for a specific segment of code like so:
-//
-// #pragma GCC diagnostic push
-// #pragma GCC diagnostic ignored "-Wpedantic"
-// ...
-// #pragma GCC diagnostic pop
-//
-// For more information on this particular compiler extension go to
-// https://gcc.gnu.org/onlinedocs/gcc/Statement-Exprs.html
+/**
+ * @brief Unwrap an expected into a stack variable or return the unexpected value
+ *
+ * This macro requires the use of non-standard C++. Compiler extensions must be enabled and
+ * -Wpedantic cannot be used. With GCC and Clang, you can disable -Wpedantic for an entire
+ * translation unit like this:
+ *
+ * ```cpp
+ * #pragma GCC diagnostic ignored "-Wpedantic"
+ * ```
+
+ * You can disable -Wpedantic for a specific segment of code like so:
+ *
+ * ```cpp
+ * #pragma GCC diagnostic push
+ * #pragma GCC diagnostic ignored "-Wpedantic"
+ * //...
+ * #pragma GCC diagnostic pop
+ * ```
+ *
+ * For more information on this particular compiler extension go to
+ * https://gcc.gnu.org/onlinedocs/gcc/Statement-Exprs.html
+ */
 #define TRY(expected)                                                              \
     ({                                                                             \
         auto const& _expected = (expected); /* Uglify name to prevent shadowing */ \

--- a/package.xml
+++ b/package.xml
@@ -13,6 +13,7 @@
   <license>BSD-3-Clause</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>doxygen</buildtool_depend>
   <buildtool_depend>git</buildtool_depend>
 
   <depend>eigen</depend>


### PR DESCRIPTION
CI fails if we require that Doxygen is found so I'm leaving that dependency as optional. Along the way I also found a few bugs and documentation deficiencies that I fixed. Now every API has Doxygen support.

Read more about `doxygen_add_docs` [here](https://cmake.org/cmake/help/latest/module/FindDoxygen.html#command:doxygen_add_docs).

<img width="700" alt="Screen Shot 2022-10-10 at 3 38 57 PM" src="https://user-images.githubusercontent.com/39244355/194956331-f0d88f60-2b6d-4a8a-8417-4f9fbcdcded0.png">

See [Halide](https://github.com/halide/Halide/blob/master/doc/CMakeLists.txt) for an example of how this is being used in practice.