### PR TITLE
Address clang-tidy findings

### DIFF
--- a/cmake/FindCatch2.cmake
+++ b/cmake/FindCatch2.cmake
@@ -4,7 +4,8 @@ FetchContent_Declare(Catch2
     GIT_REPOSITORY https://github.com/catchorg/Catch2.git
     GIT_TAG v${Catch2_FIND_VERSION})
 FetchContent_MakeAvailable(Catch2)
-set_target_properties(Catch2 PROPERTIES COMPILE_OPTIONS "")
+set_target_properties(Catch2 PROPERTIES COMPILE_OPTIONS "" EXPORT_COMPILE_COMMANDS OFF)
+set_target_properties(Catch2WithMain PROPERTIES EXPORT_COMPILE_COMMANDS OFF)
 get_target_property(CATCH2_INCLUDE_DIRS Catch2 INTERFACE_INCLUDE_DIRECTORIES)
 target_include_directories(Catch2 SYSTEM INTERFACE ${CATCH2_INCLUDE_DIRS})
 include(Catch)

--- a/include/rsl/monad.hpp
+++ b/include/rsl/monad.hpp
@@ -124,11 +124,11 @@ template <typename T, typename E>
 }
 
 template <typename>
-constexpr bool is_optional_impl = false;
+constexpr inline bool is_optional_impl = false;
 template <typename T>
-constexpr bool is_optional_impl<std::optional<T>> = true;
+constexpr inline bool is_optional_impl<std::optional<T>> = true;
 template <typename T>
-constexpr bool is_optional = is_optional_impl<std::remove_cv_t<std::remove_reference_t<T>>>;
+constexpr inline bool is_optional = is_optional_impl<std::remove_cv_t<std::remove_reference_t<T>>>;
 
 }  // namespace rsl
 

--- a/include/rsl/no_discard.hpp
+++ b/include/rsl/no_discard.hpp
@@ -12,9 +12,11 @@ namespace rsl {
  * @tparam Fn  Lambda
  */
 template <typename Fn>
-struct NoDiscard {
+class NoDiscard {
     static_assert(std::is_invocable_v<Fn()>, "Fn must be invocable");
     Fn fn_;
+
+   public:
     NoDiscard(Fn const& fn) : fn_(fn) {}
     template <typename... Ts>
     [[nodiscard]] constexpr auto operator()(Ts&&... args) const

--- a/tests/overload.cpp
+++ b/tests/overload.cpp
@@ -8,7 +8,7 @@ TEST_CASE("rsl::Overload") {
     enum class Type { INT, FLOAT, STRING } type;
     auto const overload =
         rsl::Overload{[&type](int) { type = Type::INT; }, [&type](float) { type = Type::FLOAT; },
-                      [&type](std::string) { type = Type::STRING; }};
+                      [&type](std::string const&) { type = Type::STRING; }};
 
     auto variant = std::variant<int, float, std::string>();
 

--- a/tests/random.cpp
+++ b/tests/random.cpp
@@ -6,7 +6,7 @@
 #include <thread>
 
 TEST_CASE("rsl::rng") {
-    auto const rng = &rsl::rng();
+    auto* const rng = &rsl::rng();
 
     SECTION("Repeated calls in thread yield same object") {
         CHECK(rng == &rsl::rng());


### PR DESCRIPTION
I ran clang-tidy locally and found a number of things worth cleaning up.