### PR TITLE
Add `rsl::StaticVector` and `rsl::StaticString`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@ project(rsl VERSION 0.1.1 LANGUAGES CXX DESCRIPTION "ROS Support Library")
 
 find_package(ament_cmake REQUIRED)
 find_package(Eigen3 REQUIRED)
+find_package(tcb_span REQUIRED)
 find_package(tl_expected REQUIRED)
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "(GNU|Clang)")
@@ -18,7 +19,11 @@ target_include_directories(rsl PUBLIC
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>
 )
-target_link_libraries(rsl PUBLIC Eigen3::Eigen tl_expected::tl_expected)
+target_link_libraries(rsl PUBLIC
+    Eigen3::Eigen
+    tcb_span::tcb_span
+    tl_expected::tl_expected
+)
 
 add_subdirectory(docs)
 
@@ -40,5 +45,9 @@ install(
 )
 
 ament_export_targets(export_rsl HAS_LIBRARY_TARGET)
-ament_export_dependencies(Eigen3 tl_expected)
+ament_export_dependencies(
+    Eigen3
+    tcb_span
+    tl_expected
+)
 ament_package()

--- a/include/rsl/static_string.hpp
+++ b/include/rsl/static_string.hpp
@@ -1,0 +1,59 @@
+#pragma once
+
+#include <array>
+#include <cassert>
+#include <string>
+#include <string_view>
+
+namespace rsl {
+
+/** @file */
+
+/**
+ * @brief Fixed capacity string with an implicit conversion to std::string_view. Capacity is
+ * specified as a template parameter. At runtime one may use up to the specified capacity.
+ */
+template <size_t capacity>
+class StaticString {
+    std::array<std::string::value_type, capacity> data_;
+    size_t size_;
+
+   public:
+    /**
+     * @brief Construct an empty string
+     */
+    StaticString() = default;
+
+    /**
+     * @brief Construct from a std::string
+     */
+    StaticString(std::string const& string) : size_(std::min(string.size(), capacity)) {
+        assert(string.size() <= capacity);
+        std::copy(string.cbegin(), string.cbegin() + std::string::difference_type(size_),
+                  data_.begin());
+    }
+    /**
+     * @brief Get a const begin iterator
+     */
+    auto begin() const { return data_.cbegin(); }
+
+    /**
+     * @brief Get a const end iterator
+     */
+    auto end() const { return data_.cbegin() + size_; }
+
+    /**
+     * @brief Implicit conversion to std::string_view
+     */
+    operator std::string_view() const { return std::string_view(data_.data(), size_); }
+};
+
+/**
+ * @brief Explicit conversion to std::string
+ */
+template <size_t capacity>
+auto to_string(StaticString<capacity> const& static_string) {
+    return std::string(static_string);
+}
+
+}  // namespace rsl

--- a/include/rsl/static_vector.hpp
+++ b/include/rsl/static_vector.hpp
@@ -1,0 +1,83 @@
+#pragma once
+
+#include <tcb_span/span.hpp>
+
+#include <array>
+#include <cassert>
+#include <vector>
+
+namespace rsl {
+
+/** @file */
+
+/**
+ * @brief Fixed capacity vector with an implicit conversion to tcb::span. Capacity is specified as
+ * a template parameter. At runtime one may use up to the specified capacity.
+ */
+template <typename T, size_t capacity>
+class StaticVector {
+    std::array<T, capacity> data_;
+    size_t size_;
+
+   public:
+    /**
+     * @brief Construct an empty vector
+     */
+    StaticVector() = default;
+
+    /**
+     * @brief Construct from another container
+     */
+    template <typename Collection>
+    StaticVector(Collection const& collection) : size_(std::min(collection.size(), capacity)) {
+        assert(collection.size() <= capacity);
+        std::copy(collection.cbegin(),
+                  collection.cbegin() + typename Collection::difference_type(size_), data_.begin());
+    }
+
+    /**
+     * @brief Construct from a std::initializer_list
+     */
+    StaticVector(std::initializer_list<T> const& collection)
+        : StaticVector(std::vector<T>(collection)) {}
+
+    /**
+     * @brief Get a mutable begin iterator
+     */
+    auto begin() { return data_.begin(); }
+
+    /**
+     * @brief Get a const begin iterator
+     */
+    auto begin() const { return data_.cbegin(); }
+
+    /**
+     * @brief Get a mutable end iterator
+     */
+    auto end() { return data_.begin() + size_; }
+
+    /**
+     * @brief Get a const end iterator
+     */
+    auto end() const { return data_.cbegin() + size_; }
+
+    /**
+     * @brief Implicit conversion to tcb::span<T>
+     */
+    operator tcb::span<T>() { return tcb::span<T>(data_.data(), size_); }
+
+    /**
+     * @brief Implicit conversion to tcb::span<T const>
+     */
+    operator tcb::span<T const>() const { return tcb::span<T const>(data_.data(), size_); }
+};
+
+/**
+ * @brief Explicit conversion to std::vector<T>
+ */
+template <typename T, size_t capacity>
+auto to_vector(StaticVector<T, capacity> const& static_vector) {
+    return std::vector<T>{static_vector.begin(), static_vector.end()};
+}
+
+}  // namespace rsl

--- a/package.xml
+++ b/package.xml
@@ -17,6 +17,7 @@
   <buildtool_depend>git</buildtool_depend>
 
   <depend>eigen</depend>
+  <depend>tcb_span</depend>
   <depend>tl_expected</depend>
 
   <test_depend>range-v3</test_depend>

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,6 +10,8 @@ add_executable(test-rsl
     overload.cpp
     queue.cpp
     random.cpp
+    static_string.cpp
+    static_vector.cpp
     try.cpp)
 target_link_libraries(test-rsl PRIVATE
     rsl::rsl

--- a/tests/static_string.cpp
+++ b/tests/static_string.cpp
@@ -1,0 +1,72 @@
+#include <rsl/static_string.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+
+using namespace std::literals;
+
+TEST_CASE("rsl::StaticString") {
+    SECTION("Construction") {
+        SECTION("Default constructor") {
+            auto const static_string = rsl::StaticString<10>();
+            CHECK(static_string.begin() == static_string.end());
+        }
+
+        SECTION("Collection constructor") {
+            auto const string = "Hello, world!"s;
+            auto const static_string = rsl::StaticString<14>(string);
+            CHECK(static_string.begin() != static_string.end());
+            auto begin = static_string.begin();
+            CHECK(*begin++ == 'H');
+            CHECK(*begin++ == 'e');
+            CHECK(*begin++ == 'l');
+            CHECK(*begin++ == 'l');
+            CHECK(*begin++ == 'o');
+            CHECK(*begin++ == ',');
+            CHECK(*begin++ == ' ');
+            CHECK(*begin++ == 'w');
+            CHECK(*begin++ == 'o');
+            CHECK(*begin++ == 'r');
+            CHECK(*begin++ == 'l');
+            CHECK(*begin++ == 'd');
+        }
+    }
+
+    SECTION("begin()") {
+        auto const static_string = rsl::StaticString<5>("foo");
+        CHECK(static_string.begin() == std::begin(static_string));
+        CHECK(static_string.begin() == std::cbegin(static_string));
+        CHECK(*static_string.begin() == 'f');
+    }
+
+    SECTION("end()") {
+        auto const static_string = rsl::StaticString<5>("bar");
+        CHECK(static_string.end() == std::end(static_string));
+        CHECK(static_string.end() == std::cend(static_string));
+    }
+
+    SECTION("std::string_view()") {
+        auto const static_vector = rsl::StaticString<16>("PickNik Robotics");
+        auto const string_view = std::string_view(static_vector);
+        CHECK(string_view[0] == 'P');
+        CHECK(string_view[1] == 'i');
+        CHECK(string_view[2] == 'c');
+        CHECK(string_view[3] == 'k');
+        CHECK(string_view[4] == 'N');
+        CHECK(string_view[5] == 'i');
+        CHECK(string_view[6] == 'k');
+        CHECK(string_view[7] == ' ');
+        CHECK(string_view[8] == 'R');
+        CHECK(string_view[9] == 'o');
+        CHECK(string_view[10] == 'b');
+        CHECK(string_view[11] == 'o');
+        CHECK(string_view[12] == 't');
+        CHECK(string_view[13] == 'i');
+        CHECK(string_view[14] == 'c');
+        CHECK(string_view[15] == 's');
+    }
+}
+
+TEST_CASE("rsl::to_string") {
+    CHECK(rsl::to_string(rsl::StaticString<0>()) == ""s);
+    CHECK(rsl::to_string(rsl::StaticString<10>("happy"s)) == "happy"s);
+}

--- a/tests/static_vector.cpp
+++ b/tests/static_vector.cpp
@@ -1,0 +1,87 @@
+#include <rsl/static_vector.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+
+TEST_CASE("rsl::StaticVector") {
+    SECTION("Construction") {
+        SECTION("Default constructor") {
+            auto const static_vector = rsl::StaticVector<int, 10>();
+            CHECK(static_vector.begin() == static_vector.end());
+        }
+
+        SECTION("Collection constructor") {
+            auto const vector = std::vector<int>{1, 2, 3, 4, 5};
+            auto const static_vector = rsl::StaticVector<int, 5>(vector);
+            CHECK(static_vector.begin() != static_vector.end());
+            auto i = 1;
+            for (auto const& number : static_vector) CHECK(number == i++);
+        }
+
+        SECTION("Initializer list constructor") {
+            auto const static_vector = rsl::StaticVector<int, 5>{5, 4, 3, 2, 1};
+            CHECK(static_vector.begin() != static_vector.end());
+            auto i = 5;
+            for (auto const& number : static_vector) CHECK(number == i--);
+        }
+    }
+
+    SECTION("begin()") {
+        SECTION("Non-const") {
+            auto static_vector = rsl::StaticVector<int, 5>{5, 4, 3, 2, 1};
+            CHECK(static_vector.begin() == std::begin(static_vector));
+            CHECK(static_vector.begin() == std::cbegin(static_vector));
+            CHECK(++*static_vector.begin() == 6);
+        }
+
+        SECTION("Const") {
+            auto const static_vector = rsl::StaticVector<int, 5>{5, 4, 3, 2, 1};
+            CHECK(static_vector.begin() == std::begin(static_vector));
+            CHECK(static_vector.begin() == std::cbegin(static_vector));
+            CHECK(*static_vector.begin() == 5);
+        }
+    }
+
+    SECTION("end()") {
+        SECTION("Non-const") {
+            auto static_vector = rsl::StaticVector<int, 5>{10, 9, 8, 7, 6};
+            CHECK(static_vector.end() == std::end(static_vector));
+            CHECK(static_vector.end() == std::cend(static_vector));
+            CHECK(--*(static_vector.end() - 1) == 5);
+        }
+
+        SECTION("Const") {
+            auto const static_vector = rsl::StaticVector<int, 5>{5, 4, 3, 2, 1};
+            CHECK(static_vector.end() == std::end(static_vector));
+            CHECK(static_vector.end() == std::cend(static_vector));
+            CHECK(*(static_vector.end() - 1) == 1);
+        }
+    }
+
+    SECTION("User defined conversions") {
+        SECTION("tcb::span<T>()") {
+            auto static_vector = rsl::StaticVector<int, 5>{11, 12, 13, 14, 15};
+            auto const span = tcb::span<int>(static_vector);
+            CHECK(span[0] == 11);
+            CHECK(span[1] == 12);
+            CHECK(span[2] == 13);
+            CHECK(span[3] == 14);
+            CHECK(span[4] == 15);
+        }
+
+        SECTION("tcb::span<T const>()") {
+            auto const static_vector = rsl::StaticVector<int, 5>{20, 19, 18, 17, 16};
+            auto const span = tcb::span<int const>(static_vector);
+            CHECK(span[0] == 20);
+            CHECK(span[1] == 19);
+            CHECK(span[2] == 18);
+            CHECK(span[3] == 17);
+            CHECK(span[4] == 16);
+        }
+    }
+}
+
+TEST_CASE("rsl::to_vector") {
+    CHECK(rsl::to_vector(rsl::StaticVector<int, 0>{}) == std::vector<int>{});
+    CHECK(rsl::to_vector(rsl::StaticVector<int, 5>{1, 2, 3, 4, 5}) ==
+          std::vector<int>{1, 2, 3, 4, 5});
+}


### PR DESCRIPTION
- Link rclcpp and rcb_span
- Fixed size array and string

Migrated from https://github.com/PickNikRobotics/generate_parameter_library/blob/main/parameter_traits/include/parameter_traits/fixed_size_types.hpp
