### PR TITLE
Add validators.hpp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,8 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 
 find_package(ament_cmake REQUIRED)
 find_package(Eigen3 REQUIRED)
+find_package(fmt REQUIRED)
+find_package(rclcpp REQUIRED)
 find_package(tcb_span REQUIRED)
 find_package(tl_expected REQUIRED)
 
@@ -16,6 +18,7 @@ endif()
 option(BUILD_SHARED_LIBS "Build shared libraries" ON)
 
 add_library(rsl
+    src/parameter_validators.cpp
     src/random.cpp
 )
 add_library(rsl::rsl ALIAS rsl)
@@ -26,6 +29,8 @@ target_include_directories(rsl PUBLIC
 )
 target_link_libraries(rsl PUBLIC
     Eigen3::Eigen
+    fmt::fmt
+    rclcpp::rclcpp
     tcb_span::tcb_span
     tl_expected::tl_expected
 )
@@ -52,6 +57,8 @@ install(
 ament_export_targets(export_rsl HAS_LIBRARY_TARGET)
 ament_export_dependencies(
     Eigen3
+    fmt
+    rclcpp
     tcb_span
     tl_expected
 )

--- a/include/rsl/parameter_validators.hpp
+++ b/include/rsl/parameter_validators.hpp
@@ -1,0 +1,301 @@
+#pragma once
+
+#include <rsl/algorithm.hpp>
+#include <rsl/static_string.hpp>
+#include <rsl/static_vector.hpp>
+
+#include <rcl_interfaces/msg/set_parameters_result.hpp>
+#include <rclcpp/parameter.hpp>
+#include <tl_expected/expected.hpp>
+
+#include <fmt/ranges.h>
+
+namespace rsl {
+/**
+ * @cond DETAIL
+ */
+namespace detail {
+template <typename T, typename Fn>
+[[nodiscard]] auto size_compare(rclcpp::Parameter const& parameter, size_t const size,
+                                std::string const& predicate_description, Fn const& predicate)
+    -> tl::expected<void, std::string> {
+    static constexpr auto format_string = "Length of parameter '{}' is {} but must be {} {}";
+    switch (parameter.get_type()) {
+        case rclcpp::ParameterType::PARAMETER_STRING:
+            if (auto value = parameter.get_value<std::string>(); !predicate(value.size(), size))
+                return tl::make_unexpected(fmt::format(format_string, parameter.get_name(),
+                                                       value.size(), predicate_description, size));
+            break;
+        default:
+            if (auto value = parameter.get_value<std::vector<T>>(); !predicate(value.size(), size))
+                return tl::make_unexpected(fmt::format(format_string, parameter.get_name(),
+                                                       value.size(), predicate_description, size));
+    }
+    return {};
+}
+
+template <typename T, typename Fn>
+[[nodiscard]] auto compare(rclcpp::Parameter const& parameter, T const& value,
+                           std::string const& predicate_description, Fn const& predicate)
+    -> tl::expected<void, std::string> {
+    if (auto const param_value = parameter.get_value<T>(); !predicate(param_value, value))
+        return tl::make_unexpected(fmt::format("Parameter '{}' with the value {} must be {} {}",
+                                               parameter.get_name(), param_value,
+                                               predicate_description, value));
+    return {};
+}
+}  // namespace detail
+/**
+ * @endcond
+ */
+
+/** @file Validation functions for rclcpp::Parameter */
+
+/**
+ * @brief Is every element of rclcpp::Parameter unique?
+ * @pre rclcpp::Parameter must be an array type
+ * @tparam T the interior type of array; Example: for parameter type double_array, T = double
+ * @return help string if the parameter is invalid, otherwise void
+ */
+template <typename T>
+[[nodiscard]] auto unique(rclcpp::Parameter const& parameter) -> tl::expected<void, std::string> {
+    if (is_unique(parameter.get_value<std::vector<T>>())) return {};
+    return tl::make_unexpected(
+        fmt::format("Parameter '{}' must only contain unique values", parameter.get_name()));
+}
+
+/**
+ * @brief Are the values in parameter a subset of the valid values?
+ * @pre rclcpp::Parameter must be an array type
+ * @tparam T the interior type of array; Example: for parameter type double_array, T = double
+ * @return help string if the parameter is invalid, otherwise void
+ */
+template <typename T>
+[[nodiscard]] auto subset_of(rclcpp::Parameter const& parameter, std::vector<T> const& valid_values)
+    -> tl::expected<void, std::string> {
+    auto const& values = parameter.get_value<std::vector<T>>();
+    for (auto const& value : values)
+        if (!contains(valid_values, value))
+            return tl::make_unexpected(
+                fmt::format("Entry '{}' in parameter '{}' is not in the set {{{}}}", value,
+                            parameter.get_name(), fmt::join(valid_values, ", ")));
+    return {};
+}
+
+/**
+ * @brief Is the array size of parameter equal to passed in size?
+ * @pre rclcpp::Parameter must be an array type
+ * @tparam T the interior type of array; Example: for parameter type double_array, T = double
+ * @return help string if the parameter is invalid, otherwise void
+ */
+template <typename T>
+[[nodiscard]] auto fixed_size(rclcpp::Parameter const& parameter, size_t const size) {
+    return detail::size_compare<T>(parameter, size, "equal to", std::equal_to<>());
+}
+
+/**
+ * @brief Is the array size of parameter greater than passed in size?
+ * @pre rclcpp::Parameter must be an array type
+ * @tparam T the interior type of array; Example: for parameter type double_array, T = double
+ * @return help string if the parameter is invalid, otherwise void
+ */
+template <typename T>
+[[nodiscard]] auto size_gt(rclcpp::Parameter const& parameter, size_t const size) {
+    return detail::size_compare<T>(parameter, size, "greater than", std::greater<>());
+}
+
+/**
+ * @brief Is the array size of parameter less than passed in size?
+ * @pre rclcpp::Parameter must be an array type
+ * @tparam T the interior type of array; Example: for parameter type double_array, T = double
+ * @return help string if the parameter is invalid, otherwise void
+ */
+template <typename T>
+[[nodiscard]] auto size_lt(rclcpp::Parameter const& parameter, size_t const size) {
+    return detail::size_compare<T>(parameter, size, "less than", std::less<>());
+}
+
+/**
+ * @brief Is the size of the value passed in not zero?
+ * @pre rclcpp::Parameter must be an array type or a string
+ * @tparam T the interior type of array or std::string; Example: for parameter type double_array, T
+ * = double
+ * @return help string if the parameter is invalid, otherwise void
+ */
+template <typename T>
+[[nodiscard]] auto not_empty(rclcpp::Parameter const& parameter)
+    -> tl::expected<void, std::string> {
+    switch (parameter.get_type()) {
+        case rclcpp::ParameterType::PARAMETER_STRING:
+            if (auto param_value = parameter.get_value<std::string>(); param_value.empty())
+                return tl::make_unexpected(
+                    fmt::format("Parameter '{}' cannot be empty", parameter.get_name()));
+            break;
+        default:
+            if (auto param_value = parameter.get_value<std::vector<T>>(); param_value.empty())
+                return tl::make_unexpected(
+                    fmt::format("Parameter '{}' cannot be empty", parameter.get_name()));
+    }
+    return {};
+}
+
+/**
+ * @brief Are all elements of parameter within the bounds (inclusive)?
+ * @pre rclcpp::Parameter must be an array type
+ * @tparam T the interior type of array; Example: for parameter type double_array, T = double
+ * @return help string if the parameter is invalid, otherwise void
+ */
+template <typename T>
+[[nodiscard]] auto element_bounds(rclcpp::Parameter const& parameter, T const& lower,
+                                  T const& upper) -> tl::expected<void, std::string> {
+    auto const& param_value = parameter.get_value<std::vector<T>>();
+    for (auto val : param_value)
+        if (val < lower || val > upper)
+            return tl::make_unexpected(
+                fmt::format("Value {} in parameter '{}' must be within bounds [{}, {}]", val,
+                            parameter.get_name(), lower, upper));
+    return {};
+}
+
+/**
+ * @brief Are all elements of parameter greater than lower bound?
+ * @pre rclcpp::Parameter must be an array type
+ * @tparam T the interior type of array; Example: for parameter type double_array, T = double
+ * @return help string if the parameter is invalid, otherwise void
+ */
+template <typename T>
+[[nodiscard]] auto lower_element_bounds(rclcpp::Parameter const& parameter, T const& lower)
+    -> tl::expected<void, std::string> {
+    auto const& param_value = parameter.get_value<std::vector<T>>();
+    for (auto val : param_value)
+        if (val < lower)
+            return tl::make_unexpected(
+                fmt::format("Value {} in parameter '{}' must be above lower bound of {}", val,
+                            parameter.get_name(), lower));
+    return {};
+}
+
+/**
+ * @brief Are all elements of parameter less than some upper bound?
+ * @pre rclcpp::Parameter must be an array type
+ * @tparam T the interior type of array; Example: for parameter type double_array, T = double
+ * @return help string if the parameter is invalid, otherwise void
+ */
+template <typename T>
+[[nodiscard]] auto upper_element_bounds(rclcpp::Parameter const& parameter, T const& upper)
+    -> tl::expected<void, std::string> {
+    auto const& param_value = parameter.get_value<std::vector<T>>();
+    for (auto val : param_value)
+        if (val > upper)
+            return tl::make_unexpected(
+                fmt::format("Value {} in parameter '{}' must be below upper bound of {}", val,
+                            parameter.get_name(), upper));
+    return {};
+}
+
+/**
+ * @brief Is parameter within bounds (inclusive)?
+ * @pre rclcpp::Parameter must be a non-array type
+ * @tparam T the interior type of parameter; Example: for parameter type int, T = int64_t
+ * @return help string if the parameter is invalid, otherwise void
+ */
+template <typename T>
+[[nodiscard]] auto bounds(rclcpp::Parameter const& parameter, T const& lower, T const& upper)
+    -> tl::expected<void, std::string> {
+    auto const& param_value = parameter.get_value<T>();
+    if (param_value < lower || param_value > upper)
+        return tl::make_unexpected(
+            fmt::format("Parameter '{}' with the value {} must be within bounds [{}, {}]",
+                        parameter.get_name(), param_value, lower, upper));
+    return {};
+}
+
+/**
+ * @brief Is parameter within some lower bound (same as gt_eq)?
+ * @pre rclcpp::Parameter must be a non-array type
+ * @tparam T the interior type of parameter; Example: for parameter type int, T = int64_t
+ * @return help string if the parameter is invalid, otherwise void
+ */
+template <typename T>
+[[nodiscard]] auto lower_bounds(rclcpp::Parameter const& parameter, T const& value) {
+    return detail::compare(parameter, value, "above lower bound of", std::greater_equal<T>());
+}
+
+/**
+ * @brief Is parameter within some upper bound (same as lt_eq)?
+ * @pre rclcpp::Parameter must be a non-array type
+ * @tparam T the interior type of parameter; Example: for parameter type int, T = int64_t
+ * @return help string if the parameter is invalid, otherwise void
+ */
+template <typename T>
+[[nodiscard]] auto upper_bounds(rclcpp::Parameter const& parameter, T const& value) {
+    return detail::compare(parameter, value, "below upper bound of", std::less_equal<T>());
+}
+
+/**
+ * @brief Is parameter less than some value?
+ * @pre rclcpp::Parameter must be a non-array type
+ * @tparam T the interior type of parameter; Example: for parameter type int, T = int64_t
+ * @return help string if the parameter is invalid, otherwise void
+ */
+template <typename T>
+[[nodiscard]] auto lt(rclcpp::Parameter const& parameter, T const& value) {
+    return detail::compare(parameter, value, "less than", std::less<T>());
+}
+
+/**
+ * @brief Is parameter greater than some value?
+ * @pre rclcpp::Parameter must be a non-array type
+ * @tparam T the interior type of parameter; Example: for parameter type int, T = int64_t
+ * @return help string if the parameter is invalid, otherwise void
+ */
+template <typename T>
+[[nodiscard]] auto gt(rclcpp::Parameter const& parameter, T const& value) {
+    return detail::compare(parameter, value, "greater than", std::greater<T>());
+}
+
+/**
+ * @brief Is parameter less than or equal to some value?
+ * @pre rclcpp::Parameter must be a non-array type
+ * @tparam T the interior type of parameter; Example: for parameter type int, T = int64_t
+ * @return help string if the parameter is invalid, otherwise void
+ */
+template <typename T>
+[[nodiscard]] auto lt_eq(rclcpp::Parameter const& parameter, T const& value) {
+    return detail::compare(parameter, value, "less than or equal to", std::less_equal<T>());
+}
+
+/**
+ * @brief Is parameter greater than or equal to some value?
+ * @pre rclcpp::Parameter must be a non-array type
+ * @tparam T the interior type of parameter; Example: for parameter type int, T = int64_t
+ * @return help string if the parameter is invalid, otherwise void
+ */
+template <typename T>
+[[nodiscard]] auto gt_eq(rclcpp::Parameter const& parameter, T const& value) {
+    return detail::compare(parameter, value, "greater than or equal to", std::greater_equal<T>());
+}
+
+/**
+ * @brief Is the parameter value one of a set of values?
+ * @pre rclcpp::Parameter must be a non-array type
+ * @tparam T the interior type of parameter; Example: for parameter type int, T = int64_t
+ * @return help string if the parameter is invalid, otherwise void
+ */
+template <typename T>
+[[nodiscard]] auto one_of(rclcpp::Parameter const& parameter, std::vector<T> const& collection)
+    -> tl::expected<void, std::string> {
+    auto const& param_value = parameter.get_value<T>();
+    if (contains(collection, param_value)) return {};
+    return tl::make_unexpected(fmt::format(
+        "Parameter '{}' with the value {} is not in the set {{{}}}", parameter.get_name(),
+        param_value, fmt::format("{}", fmt::join(collection, ", "))));
+}
+
+/**
+ * @brief Convert the result of a validator function into a SetParametersResult msg
+ */
+[[nodiscard]] auto to_parameter_result_msg(tl::expected<void, std::string> const& result)
+    -> rcl_interfaces::msg::SetParametersResult;
+
+}  // namespace rsl

--- a/include/rsl/static_vector.hpp
+++ b/include/rsl/static_vector.hpp
@@ -77,7 +77,7 @@ class StaticVector {
  */
 template <typename T, size_t capacity>
 [[nodiscard]] auto to_vector(StaticVector<T, capacity> const& static_vector) {
-    return std::vector<T>{static_vector.begin(), static_vector.end()};
+    return std::vector<T>(static_vector.begin(), static_vector.end());
 }
 
 }  // namespace rsl

--- a/package.xml
+++ b/package.xml
@@ -17,6 +17,8 @@
   <buildtool_depend>git</buildtool_depend>
 
   <depend>eigen</depend>
+  <depend>fmt</depend>
+  <depend>rclcpp</depend>
   <depend>tcb_span</depend>
   <depend>tl_expected</depend>
 

--- a/src/parameter_validators.cpp
+++ b/src/parameter_validators.cpp
@@ -1,0 +1,13 @@
+#include <rsl/parameter_validators.hpp>
+
+namespace rsl {
+
+auto to_parameter_result_msg(tl::expected<void, std::string> const& result)
+    -> rcl_interfaces::msg::SetParametersResult {
+    auto msg = rcl_interfaces::msg::SetParametersResult();
+    msg.successful = result.has_value();
+    msg.reason = result.has_value() ? "" : result.error();
+    return msg;
+}
+
+}  // namespace rsl

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -8,6 +8,7 @@ add_executable(test-rsl
     monad.cpp
     no_discard.cpp
     overload.cpp
+    parameter_validators.cpp
     queue.cpp
     random.cpp
     static_string.cpp

--- a/tests/parameter_validators.cpp
+++ b/tests/parameter_validators.cpp
@@ -1,0 +1,382 @@
+#include <rsl/parameter_validators.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+
+using namespace std::literals;
+using rclcpp::Parameter;
+
+TEST_CASE("rsl::unique") {
+    CHECK(rsl::unique<std::string>(Parameter("", std::vector<std::string>{"", "1", "2"})));
+    CHECK(rsl::unique<std::string>(Parameter("", std::vector<std::string>{})));
+    CHECK(!rsl::unique<std::string>(Parameter("", std::vector<std::string>{"foo", "foo"})));
+
+    CHECK(rsl::unique<double>(Parameter("", std::vector<double>{1.0, 2.2, 1.1})));
+    CHECK(rsl::unique<double>(Parameter("", std::vector<double>{})));
+    CHECK(!rsl::unique<double>(Parameter("", std::vector<double>{1.1, 1.1})));
+
+    CHECK(rsl::unique<int64_t>(Parameter("", std::vector<int64_t>{1, 2, 3})));
+    CHECK(rsl::unique<int64_t>(Parameter("", std::vector<int64_t>{})));
+    CHECK(!rsl::unique<int64_t>(Parameter("", std::vector<int64_t>{-1, -1})));
+
+    CHECK(rsl::unique<bool>(Parameter("", std::vector<bool>{true, false})));
+    CHECK(rsl::unique<bool>(Parameter("", std::vector<bool>{})));
+    CHECK(!rsl::unique<bool>(Parameter("", std::vector<bool>{false, false})));
+
+    auto const result =
+        rsl::unique<std::string>(Parameter("test", std::vector<std::string>{"foo", "foo"}));
+    REQUIRE(!result);
+    CHECK(result.error() == "Parameter 'test' must only contain unique values");
+}
+
+TEST_CASE("rsl::subset_of") {
+    CHECK(rsl::subset_of<std::string>(Parameter("", std::vector<std::string>{"", "1", "2"}),
+                                      std::vector<std::string>{"", "1", "2", "three"}));
+    CHECK(rsl::subset_of<std::string>(Parameter("", std::vector<std::string>{}),
+                                      std::vector<std::string>{"", "1", "2", "three"}));
+    CHECK(!rsl::subset_of<std::string>(Parameter("", std::vector<std::string>{"foo", "foo"}),
+                                       std::vector<std::string>{"", "1", "2", "three"}));
+
+    CHECK(rsl::subset_of<double>(Parameter("", std::vector<double>{1.0, 2.2, 1.1}),
+                                 std::vector<double>{1.0, 2.2, 1.1}));
+    CHECK(
+        rsl::subset_of<double>(Parameter("", std::vector<double>{}), std::vector<double>{10, 22}));
+    CHECK(!rsl::subset_of<double>(Parameter("", std::vector<double>{1.1, 1.1}),
+                                  std::vector<double>{1.0, 2.2}));
+
+    CHECK(rsl::subset_of<int64_t>(Parameter("", std::vector<int64_t>{1, 2, 3}),
+                                  std::vector<int64_t>{1, 2, 3}));
+    CHECK(rsl::subset_of<int64_t>(Parameter("", std::vector<int64_t>{}),
+                                  std::vector<int64_t>{1, 2, 3}));
+    CHECK(!rsl::subset_of<int64_t>(Parameter("", std::vector<int64_t>{-1, -1}),
+                                   std::vector<int64_t>{1, 2, 3}));
+
+    CHECK(rsl::subset_of<bool>(Parameter("", std::vector<bool>{true, false}),
+                               std::vector<bool>{true, false}));
+    CHECK(rsl::subset_of<bool>(Parameter("", std::vector<bool>{}), std::vector<bool>{true, false}));
+    CHECK(!rsl::subset_of<bool>(Parameter("", std::vector<bool>{false, false}),
+                                std::vector<bool>{true}));
+
+    auto const result =
+        rsl::subset_of<std::string>(Parameter("test", std::vector<std::string>{"foo", "foo"}),
+                                    std::vector<std::string>{"", "1", "2", "three"});
+    REQUIRE(!result);
+    CHECK(result.error() == "Entry 'foo' in parameter 'test' is not in the set {, 1, 2, three}");
+}
+
+TEST_CASE("rsl::fixed_size") {
+    CHECK(rsl::fixed_size<std::string>(Parameter("", "foo"), 3));
+    CHECK(rsl::fixed_size<std::string>(Parameter("", ""), 0));
+    CHECK(!rsl::fixed_size<std::string>(Parameter("", "foo"), 0));
+    CHECK(!rsl::fixed_size<std::string>(Parameter("", "foo"), 5));
+
+    CHECK(rsl::fixed_size<std::string>(Parameter("", std::vector<std::string>{"", "1", "2"}), 3));
+    CHECK(rsl::fixed_size<std::string>(Parameter("", std::vector<std::string>{}), 0));
+    CHECK(!rsl::fixed_size<std::string>(Parameter("", std::vector<std::string>{"foo", "foo"}), 3));
+
+    CHECK(rsl::fixed_size<double>(Parameter("", std::vector<double>{1.0, 2.2, 1.1}), 3));
+    CHECK(rsl::fixed_size<double>(Parameter("", std::vector<double>{}), 0));
+    CHECK(!rsl::fixed_size<double>(Parameter("", std::vector<double>{1.1, 1.1}), 3));
+
+    CHECK(rsl::fixed_size<int64_t>(Parameter("", std::vector<int64_t>{1, 2, 3}), 3));
+    CHECK(rsl::fixed_size<int64_t>(Parameter("", std::vector<int64_t>{}), 0));
+    CHECK(!rsl::fixed_size<int64_t>(Parameter("", std::vector<int64_t>{-1, -1}), 0));
+
+    CHECK(rsl::fixed_size<bool>(Parameter("", std::vector<bool>{true, false}), 2));
+    CHECK(rsl::fixed_size<bool>(Parameter("", std::vector<bool>{}), 0));
+    CHECK(!rsl::fixed_size<bool>(Parameter("", std::vector<bool>{false, false}), 0));
+
+    auto const result = rsl::fixed_size<std::string>(Parameter("test", "foo"), 0);
+    REQUIRE(!result);
+    CHECK(result.error() == "Length of parameter 'test' is 3 but must be equal to 0");
+}
+
+TEST_CASE("rsl::size_gt") {
+    CHECK(rsl::size_gt<std::string>(Parameter("", "foo"), 2));
+    CHECK(!rsl::size_gt<std::string>(Parameter("", ""), 0));
+    CHECK(!rsl::size_gt<std::string>(Parameter("", "foo"), 5));
+
+    CHECK(rsl::size_gt<std::string>(Parameter("", std::vector<std::string>{"", "1", "2"}), 1));
+    CHECK(!rsl::size_gt<std::string>(Parameter("", std::vector<std::string>{}), 0));
+    CHECK(!rsl::size_gt<std::string>(Parameter("", std::vector<std::string>{"foo", "foo"}), 3));
+
+    CHECK(rsl::size_gt<double>(Parameter("", std::vector<double>{1.0, 2.2, 1.1}), 2));
+    CHECK(!rsl::size_gt<double>(Parameter("", std::vector<double>{}), 0));
+    CHECK(!rsl::size_gt<double>(Parameter("", std::vector<double>{1.1, 1.1}), 3));
+
+    CHECK(rsl::size_gt<int64_t>(Parameter("", std::vector<int64_t>{1, 2, 3}), 2));
+    CHECK(!rsl::size_gt<int64_t>(Parameter("", std::vector<int64_t>{}), 0));
+    CHECK(rsl::size_gt<int64_t>(Parameter("", std::vector<int64_t>{-1, -1}), 0));
+
+    CHECK(rsl::size_gt<bool>(Parameter("", std::vector<bool>{true, false}), 0));
+    CHECK(!rsl::size_gt<bool>(Parameter("", std::vector<bool>{}), 0));
+    CHECK(rsl::size_gt<bool>(Parameter("", std::vector<bool>{false, false}), 0));
+
+    auto const result = rsl::size_gt<std::string>(Parameter("test", ""), 0);
+    REQUIRE(!result);
+    CHECK(result.error() == "Length of parameter 'test' is 0 but must be greater than 0");
+}
+
+TEST_CASE("rsl::size_lt") {
+    CHECK(rsl::size_lt<std::string>(Parameter("", "foo"), 5));
+    CHECK(!rsl::size_lt<std::string>(Parameter("", ""), 0));
+    CHECK(!rsl::size_lt<std::string>(Parameter("", "foo"), 3));
+
+    CHECK(!rsl::size_lt<std::string>(Parameter("", std::vector<std::string>{"", "1", "2"}), 1));
+    CHECK(!rsl::size_lt<std::string>(Parameter("", std::vector<std::string>{}), 0));
+    CHECK(rsl::size_lt<std::string>(Parameter("", std::vector<std::string>{"foo", "foo"}), 3));
+
+    CHECK(!rsl::size_lt<double>(Parameter("", std::vector<double>{1.0, 2.2, 1.1}), 2));
+    CHECK(!rsl::size_lt<double>(Parameter("", std::vector<double>{}), 0));
+    CHECK(rsl::size_lt<double>(Parameter("", std::vector<double>{1.1, 1.1}), 3));
+
+    CHECK(!rsl::size_lt<int64_t>(Parameter("", std::vector<int64_t>{1, 2, 3}), 2));
+    CHECK(!rsl::size_lt<int64_t>(Parameter("", std::vector<int64_t>{}), 0));
+    CHECK(!rsl::size_lt<int64_t>(Parameter("", std::vector<int64_t>{-1, -1}), 0));
+
+    CHECK(rsl::size_lt<bool>(Parameter("", std::vector<bool>{true, false}), 3));
+    CHECK(!rsl::size_lt<bool>(Parameter("", std::vector<bool>{}), 0));
+    CHECK(!rsl::size_lt<bool>(Parameter("", std::vector<bool>{false, false}), 0));
+
+    auto const result = rsl::size_lt<std::string>(Parameter("test", "foo"), 3);
+    REQUIRE(!result);
+    CHECK(result.error() == "Length of parameter 'test' is 3 but must be less than 3");
+}
+
+TEST_CASE("rsl::not_empty") {
+    CHECK(rsl::not_empty<std::string>(Parameter("", "foo")));
+    CHECK(!rsl::not_empty<std::string>(Parameter("", "")));
+
+    CHECK(rsl::not_empty<std::string>(Parameter("", std::vector<std::string>{"", "1", "2"})));
+    CHECK(!rsl::not_empty<std::string>(Parameter("", std::vector<std::string>{})));
+
+    CHECK(rsl::not_empty<double>(Parameter("", std::vector<double>{1.0, 2.2, 1.1})));
+    CHECK(!rsl::not_empty<double>(Parameter("", std::vector<double>{})));
+
+    CHECK(rsl::not_empty<int64_t>(Parameter("", std::vector<int64_t>{1, 2, 3})));
+    CHECK(!rsl::not_empty<int64_t>(Parameter("", std::vector<int64_t>{})));
+
+    CHECK(rsl::not_empty<bool>(Parameter("", std::vector<bool>{true, false})));
+    CHECK(!rsl::not_empty<bool>(Parameter("", std::vector<bool>{})));
+
+    auto const result = rsl::not_empty<std::string>(Parameter("test", ""));
+    REQUIRE(!result);
+    CHECK(result.error() == "Parameter 'test' cannot be empty");
+}
+
+TEST_CASE("rsl::element_bounds") {
+    CHECK(rsl::element_bounds<double>(Parameter("", std::vector<double>{1.0, 2.2, 1.1}), 0.0, 3.0));
+    CHECK(rsl::element_bounds<double>(Parameter("", std::vector<double>{}), 0.0, 1.0));
+
+    CHECK(rsl::element_bounds<int64_t>(Parameter("", std::vector<int64_t>{1, 2, 3}), 0, 5));
+    CHECK(!rsl::element_bounds<int64_t>(Parameter("", std::vector<int64_t>{1, 2, 3}), -5, 0));
+    CHECK(rsl::element_bounds<int64_t>(Parameter("", std::vector<int64_t>{}), 0, 1));
+
+    CHECK(rsl::element_bounds<bool>(Parameter("", std::vector<bool>{true, false}), false, true));
+    CHECK(!rsl::element_bounds<bool>(Parameter("", std::vector<bool>{true, false}), true, false));
+    CHECK(!rsl::element_bounds<bool>(Parameter("", std::vector<bool>{true, false}), false, false));
+    CHECK(rsl::element_bounds<bool>(Parameter("", std::vector<bool>{}), true, false));
+
+    auto const result =
+        rsl::element_bounds<int64_t>(Parameter("test", std::vector<int64_t>{1, 2, 3}), -5, 0);
+    REQUIRE(!result);
+    CHECK(result.error() == "Value 1 in parameter 'test' must be within bounds [-5, 0]");
+}
+
+TEST_CASE("rsl::lower_element_bounds") {
+    CHECK(
+        rsl::lower_element_bounds<double>(Parameter("", std::vector<double>{1.0, 2.2, 1.1}), 0.0));
+    CHECK(rsl::lower_element_bounds<double>(Parameter("", std::vector<double>{}), 0.0));
+
+    CHECK(rsl::lower_element_bounds<int64_t>(Parameter("", std::vector<int64_t>{1, 2, 3}), 0));
+    CHECK(!rsl::lower_element_bounds<int64_t>(Parameter("", std::vector<int64_t>{1, 2, 3}), 3));
+    CHECK(rsl::lower_element_bounds<int64_t>(Parameter("", std::vector<int64_t>{}), 0));
+
+    CHECK(rsl::lower_element_bounds<bool>(Parameter("", std::vector<bool>{true, false}), false));
+    CHECK(!rsl::lower_element_bounds<bool>(Parameter("", std::vector<bool>{true, false}), true));
+    CHECK(rsl::lower_element_bounds<bool>(Parameter("", std::vector<bool>{true, false}), false));
+    CHECK(rsl::lower_element_bounds<bool>(Parameter("", std::vector<bool>{}), true));
+
+    auto const result =
+        rsl::lower_element_bounds<int64_t>(Parameter("test", std::vector<int64_t>{1, 2, 3}), 3);
+    REQUIRE(!result);
+    CHECK(result.error() == "Value 1 in parameter 'test' must be above lower bound of 3");
+}
+
+TEST_CASE("rsl::upper_element_bounds") {
+    CHECK(
+        !rsl::upper_element_bounds<double>(Parameter("", std::vector<double>{1.0, 2.2, 1.1}), 0.0));
+    CHECK(rsl::upper_element_bounds<double>(Parameter("", std::vector<double>{}), 0.0));
+
+    CHECK(!rsl::upper_element_bounds<int64_t>(Parameter("", std::vector<int64_t>{1, 2, 3}), 0));
+    CHECK(rsl::upper_element_bounds<int64_t>(Parameter("", std::vector<int64_t>{1, 2, 3}), 3));
+    CHECK(rsl::upper_element_bounds<int64_t>(Parameter("", std::vector<int64_t>{}), 0));
+
+    CHECK(!rsl::upper_element_bounds<bool>(Parameter("", std::vector<bool>{true, false}), false));
+    CHECK(rsl::upper_element_bounds<bool>(Parameter("", std::vector<bool>{true, false}), true));
+    CHECK(!rsl::upper_element_bounds<bool>(Parameter("", std::vector<bool>{true, false}), false));
+    CHECK(rsl::upper_element_bounds<bool>(Parameter("", std::vector<bool>{}), true));
+
+    auto const result = rsl::upper_element_bounds<double>(
+        Parameter("test", std::vector<double>{1.0, 2.2, 1.1}), 0.0);
+    REQUIRE(!result);
+    CHECK(result.error() == "Value 1 in parameter 'test' must be below upper bound of 0");
+}
+
+TEST_CASE("rsl::bounds") {
+    CHECK(rsl::bounds<double>(Parameter("", 1.0), 1.0, 5.0));
+    CHECK(rsl::bounds<double>(Parameter("", 4.3), 1.0, 5.0));
+    CHECK(rsl::bounds<double>(Parameter("", 5.0), 1.0, 5.0));
+    CHECK(!rsl::bounds<double>(Parameter("", -4.3), 1.0, 5.0));
+    CHECK(!rsl::bounds<double>(Parameter("", 10.2), 1.0, 5.0));
+
+    CHECK(rsl::bounds<int64_t>(Parameter("", 1), 1, 5));
+    CHECK(rsl::bounds<int64_t>(Parameter("", 4), 1, 5));
+    CHECK(rsl::bounds<int64_t>(Parameter("", 5), 1, 5));
+    CHECK(!rsl::bounds<int64_t>(Parameter("", -4), 1, 5));
+    CHECK(!rsl::bounds<int64_t>(Parameter("", 10), 1, 5));
+
+    CHECK(rsl::bounds<bool>(Parameter("", true), false, true));
+    CHECK(!rsl::bounds<bool>(Parameter("", false), true, true));
+    CHECK(!rsl::bounds<bool>(Parameter("", true), false, false));
+
+    CHECK_THROWS(rsl::bounds<int64_t>(Parameter("", ""), 1, 5));
+    CHECK_THROWS(rsl::bounds<std::string>(Parameter("", 4), "", "foo"));
+
+    auto const result = rsl::bounds<double>(Parameter("test", -4.3), 1.0, 5.0);
+    REQUIRE(!result);
+    CHECK(result.error() == "Parameter 'test' with the value -4.3 must be within bounds [1, 5]");
+}
+
+TEST_CASE("rsl::lower_bounds") {
+    CHECK(rsl::lower_bounds<double>(Parameter("", 2.0), 2.0));
+    CHECK(rsl::lower_bounds<double>(Parameter("", 4.3), 1.0));
+    CHECK(!rsl::lower_bounds<double>(Parameter("", -4.3), 1.0));
+
+    CHECK(rsl::lower_bounds<int64_t>(Parameter("", 1), 1));
+    CHECK(rsl::lower_bounds<int64_t>(Parameter("", 4), 1));
+    CHECK(!rsl::lower_bounds<int64_t>(Parameter("", -4), 1));
+
+    CHECK(rsl::lower_bounds<bool>(Parameter("", true), false));
+    CHECK(!rsl::lower_bounds<bool>(Parameter("", false), true));
+    CHECK(rsl::lower_bounds<bool>(Parameter("", true), true));
+
+    auto const result = rsl::lower_bounds<double>(Parameter("test", -4.3), 1.0);
+    REQUIRE(!result);
+    CHECK(result.error() == "Parameter 'test' with the value -4.3 must be above lower bound of 1");
+}
+
+TEST_CASE("rsl::upper_bounds") {
+    CHECK(rsl::upper_bounds<double>(Parameter("", 2.0), 2.0));
+    CHECK(!rsl::upper_bounds<double>(Parameter("", 4.3), 1.0));
+    CHECK(rsl::upper_bounds<double>(Parameter("", -4.3), 1.0));
+
+    CHECK(rsl::upper_bounds<int64_t>(Parameter("", 1), 1));
+    CHECK(!rsl::upper_bounds<int64_t>(Parameter("", 4), 1));
+    CHECK(rsl::upper_bounds<int64_t>(Parameter("", -4), 1));
+
+    CHECK(!rsl::upper_bounds<bool>(Parameter("", true), false));
+    CHECK(rsl::upper_bounds<bool>(Parameter("", false), true));
+    CHECK(rsl::upper_bounds<bool>(Parameter("", true), true));
+
+    auto const result = rsl::upper_bounds<double>(Parameter("test", 4.3), 1.0);
+    REQUIRE(!result);
+    CHECK(result.error() == "Parameter 'test' with the value 4.3 must be below upper bound of 1");
+}
+
+TEST_CASE("rsl::lt") {
+    CHECK(!rsl::lt<double>(Parameter("", 2.0), 2.0));
+    CHECK(!rsl::lt<double>(Parameter("", 4.3), 1.0));
+    CHECK(rsl::lt<double>(Parameter("", -4.3), 1.0));
+
+    CHECK(!rsl::lt<int64_t>(Parameter("", 1), 1));
+    CHECK(!rsl::lt<int64_t>(Parameter("", 4), 1));
+    CHECK(rsl::lt<int64_t>(Parameter("", -4), 1));
+
+    CHECK(!rsl::lt<bool>(Parameter("", true), false));
+    CHECK(rsl::lt<bool>(Parameter("", false), true));
+    CHECK(!rsl::lt<bool>(Parameter("", true), true));
+
+    auto const result = rsl::lt<double>(Parameter("test", 4.3), 1.0);
+    REQUIRE(!result);
+    CHECK(result.error() == "Parameter 'test' with the value 4.3 must be less than 1");
+}
+
+TEST_CASE("rsl::gt") {
+    CHECK(!rsl::gt<double>(Parameter("", 2.0), 2.0));
+    CHECK(rsl::gt<double>(Parameter("", 4.3), 1.0));
+    CHECK(!rsl::gt<double>(Parameter("", -4.3), 1.0));
+
+    CHECK(!rsl::gt<int64_t>(Parameter("", 1), 1));
+    CHECK(rsl::gt<int64_t>(Parameter("", 4), 1));
+    CHECK(!rsl::gt<int64_t>(Parameter("", -4), 1));
+
+    CHECK(rsl::gt<bool>(Parameter("", true), false));
+    CHECK(!rsl::gt<bool>(Parameter("", false), true));
+    CHECK(!rsl::gt<bool>(Parameter("", true), true));
+
+    auto const result = rsl::gt<int64_t>(Parameter("test", 1), 1);
+    REQUIRE(!result);
+    CHECK(result.error() == "Parameter 'test' with the value 1 must be greater than 1");
+}
+
+TEST_CASE("rsl::lt_eq") {
+    CHECK(rsl::lt_eq<double>(Parameter("", 2.0), 2.0));
+    CHECK(!rsl::lt_eq<double>(Parameter("", 4.3), 1.0));
+    CHECK(rsl::lt_eq<double>(Parameter("", -4.3), 1.0));
+
+    CHECK(rsl::lt_eq<int64_t>(Parameter("", 1), 1));
+    CHECK(!rsl::lt_eq<int64_t>(Parameter("", 4), 1));
+    CHECK(rsl::lt_eq<int64_t>(Parameter("", -4), 1));
+
+    CHECK(!rsl::lt_eq<bool>(Parameter("", true), false));
+    CHECK(rsl::lt_eq<bool>(Parameter("", false), true));
+    CHECK(rsl::lt_eq<bool>(Parameter("", true), true));
+
+    auto const result = rsl::lt_eq<double>(Parameter("test", 4.3), 1.0);
+    REQUIRE(!result);
+    CHECK(result.error() == "Parameter 'test' with the value 4.3 must be less than or equal to 1");
+}
+
+TEST_CASE("rsl::gt_eq") {
+    CHECK(rsl::gt_eq<double>(Parameter("", 2.0), 2.0));
+    CHECK(rsl::gt_eq<double>(Parameter("", 4.3), 1.0));
+    CHECK(!rsl::gt_eq<double>(Parameter("", -4.3), 1.0));
+
+    CHECK(rsl::gt_eq<int64_t>(Parameter("", 1), 1));
+    CHECK(rsl::gt_eq<int64_t>(Parameter("", 4), 1));
+    CHECK(!rsl::gt_eq<int64_t>(Parameter("", -4), 1));
+
+    CHECK(rsl::gt_eq<bool>(Parameter("", true), false));
+    CHECK(!rsl::gt_eq<bool>(Parameter("", false), true));
+    CHECK(rsl::gt_eq<bool>(Parameter("", true), true));
+
+    auto const result = rsl::gt_eq<double>(Parameter("test", -4.3), 1.0);
+    REQUIRE(!result);
+    CHECK(result.error() ==
+          "Parameter 'test' with the value -4.3 must be greater than or equal to 1");
+}
+
+TEST_CASE("rsl::one_of") {
+    CHECK(rsl::one_of<double>(Parameter("", 2.0), std::vector<double>{2.0}));
+    CHECK(rsl::one_of<double>(Parameter("", 2.0), std::vector<double>{1.0, 2.0, 3.5}));
+    CHECK(!rsl::one_of<double>(Parameter("", 0.0), std::vector<double>{1.0, 2.0, 3.5}));
+    CHECK(!rsl::one_of<double>(Parameter("", 0.0), std::vector<double>{}));
+
+    CHECK(rsl::one_of<int64_t>(Parameter("", 1), std::vector<int64_t>{1}));
+    CHECK(rsl::one_of<int64_t>(Parameter("", 1), std::vector<int64_t>{1, 2, 3, 4}));
+    CHECK(!rsl::one_of<int64_t>(Parameter("", 0), std::vector<int64_t>{1, 2, 3, 4}));
+    CHECK(!rsl::one_of<int64_t>(Parameter("", 0), std::vector<int64_t>{}));
+
+    CHECK(!rsl::one_of<bool>(Parameter("", true), std::vector<bool>{false}));
+    CHECK(rsl::one_of<bool>(Parameter("", true), std::vector<bool>{false, true}));
+    CHECK(rsl::one_of<bool>(Parameter("", true), std::vector<bool>{true}));
+    CHECK(!rsl::one_of<bool>(Parameter("", true), std::vector<bool>{}));
+
+    CHECK(rsl::one_of(Parameter("", "foo"), std::vector<std::string>{"foo", "baz"}));
+    CHECK(!rsl::one_of(Parameter("", ""), std::vector<std::string>{"foo", "baz"}));
+
+    auto const result =
+        rsl::one_of<double>(Parameter("test", 0.0), std::vector<double>{1.0, 2.0, 3.5});
+    REQUIRE(!result);
+    CHECK(result.error() == "Parameter 'test' with the value 0 is not in the set {1, 2, 3.5}");
+}


### PR DESCRIPTION
I integrated [this file](https://github.com/PickNikRobotics/generate_parameter_library/blob/main/parameter_traits/include/parameter_traits/validators.hpp) and made some changes to match RSL conventions. One big change was replacing `Result` with `tl::expected<void, std::string>` which I think better expresses out intent.

There are still some TODOs for writing more docs and tests but this is good enough to warrant a draft PR.