### PR TITLE
Remove C compiler settings

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -13,7 +13,6 @@
             "binaryDir": "${sourceDir}/build/relwithdebinfo",
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "RelWithDebInfo",
-                "CMAKE_C_COMPILER_LAUNCHER": "ccache",
                 "CMAKE_CXX_COMPILER_LAUNCHER": "ccache",
                 "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
                 "CMAKE_EXE_LINKER_FLAGS": "-fuse-ld=lld",
@@ -48,7 +47,6 @@
             "displayName": "Address sanitizer debug",
             "binaryDir": "${sourceDir}/build/asan",
             "cacheVariables": {
-                "CMAKE_C_FLAGS": "-fsanitize=address",
                 "CMAKE_CXX_FLAGS": "-fsanitize=address"
             }
         },
@@ -58,7 +56,6 @@
             "displayName": "Code coverage reporting",
             "binaryDir": "${sourceDir}/build/codecov",
             "cacheVariables": {
-                "CMAKE_C_FLAGS": "--coverage",
                 "CMAKE_CXX_FLAGS": "--coverage"
             }
         }


### PR DESCRIPTION
There is no C code in RSL so we don't need to specify these C compiler settings.