### PR TITLE
Clean up static containers implementation

### DIFF
--- a/include/rsl/static_string.hpp
+++ b/include/rsl/static_string.hpp
@@ -35,12 +35,12 @@ class StaticString {
     /**
      * @brief Get a const begin iterator
      */
-    auto begin() const { return data_.cbegin(); }
+    [[nodiscard]] auto begin() const { return data_.cbegin(); }
 
     /**
      * @brief Get a const end iterator
      */
-    auto end() const { return data_.cbegin() + size_; }
+    [[nodiscard]] auto end() const { return data_.cbegin() + size_; }
 
     /**
      * @brief Implicit conversion to std::string_view

--- a/include/rsl/static_vector.hpp
+++ b/include/rsl/static_vector.hpp
@@ -44,22 +44,22 @@ class StaticVector {
     /**
      * @brief Get a mutable begin iterator
      */
-    auto begin() { return data_.begin(); }
+    [[nodiscard]] auto begin() { return data_.begin(); }
 
     /**
      * @brief Get a const begin iterator
      */
-    auto begin() const { return data_.cbegin(); }
+    [[nodiscard]] auto begin() const { return data_.cbegin(); }
 
     /**
      * @brief Get a mutable end iterator
      */
-    auto end() { return data_.begin() + size_; }
+    [[nodiscard]] auto end() { return data_.begin() + size_; }
 
     /**
      * @brief Get a const end iterator
      */
-    auto end() const { return data_.cbegin() + size_; }
+    [[nodiscard]] auto end() const { return data_.cbegin() + size_; }
 
     /**
      * @brief Implicit conversion to tcb::span<T>

--- a/tests/static_string.cpp
+++ b/tests/static_string.cpp
@@ -15,7 +15,7 @@ TEST_CASE("rsl::StaticString") {
             auto const string = "Hello, world!"s;
             auto const static_string = rsl::StaticString<14>(string);
             CHECK(static_string.begin() != static_string.end());
-            auto begin = static_string.begin();
+            auto const* begin = static_string.begin();
             CHECK(*begin++ == 'H');
             CHECK(*begin++ == 'e');
             CHECK(*begin++ == 'l');

--- a/tests/static_vector.cpp
+++ b/tests/static_vector.cpp
@@ -81,7 +81,7 @@ TEST_CASE("rsl::StaticVector") {
 }
 
 TEST_CASE("rsl::to_vector") {
-    CHECK(rsl::to_vector(rsl::StaticVector<int, 0>{}) == std::vector<int>{});
+    CHECK(rsl::to_vector(rsl::StaticVector<int, 0>{}).empty());
     CHECK(rsl::to_vector(rsl::StaticVector<int, 5>{1, 2, 3, 4, 5}) ==
           std::vector<int>{1, 2, 3, 4, 5});
 }


### PR DESCRIPTION
We overlooked a few things. clang-tidy caught most of these things so that puts more pressure on us getting that integration working soon before we let more little issues slip through.