### PR TITLE
Add clang-tidy integration

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,36 @@
+Checks: >
+  -*,
+  bugprone-*,
+  clang-analyzer-*,
+  concurrency-*,
+  cppcoreguidelines-*,
+  misc-*,
+  modernize-*,
+  performance-*,
+  portability-*,
+  readability-*,
+  -concurrency-mt-unsafe,
+  -cppcoreguidelines-avoid-magic-numbers,
+  -cppcoreguidelines-macro-usage,
+  -cppcoreguidelines-pro-bounds-pointer-arithmetic,
+  -misc-non-private-member-variables-in-classes,
+  -modernize-avoid-bind,
+  -modernize-use-trailing-return-type,
+  -readability-braces-around-statements,
+  -readability-function-cognitive-complexity,
+  -readability-identifier-length,
+  -readability-magic-numbers,
+  -readability-uppercase-literal-suffix,
+CheckOptions:
+  - { key: readability-identifier-naming.ClassCase,           value: CamelCase  }
+  - { key: readability-identifier-naming.EnumCase,            value: CamelCase  }
+  - { key: readability-identifier-naming.TypeAliasCase,       value: CamelCase  }
+  - { key: readability-identifier-naming.NamespaceCase,       value: lower_case }
+  - { key: readability-identifier-naming.FunctionCase,        value: lower_case }
+  - { key: readability-identifier-naming.VariableCase,        value: lower_case }
+  - { key: readability-identifier-naming.ParameterCase,       value: lower_case }
+  - { key: readability-identifier-naming.MemberCase,          value: lower_case }
+  - { key: readability-identifier-naming.PrivateMemberCase,   value: lower_case }
+  - { key: readability-identifier-naming.PrivateMemberSuffix, value: _ }
+HeaderFilterRegex: '.*'
+WarningsAsErrors: '*'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,6 +36,8 @@ jobs:
         run: cmake --build build/${{ matrix.preset }}
       - name: Test
         run: ctest --test-dir build/${{ matrix.preset }} --rerun-failed --output-on-failure
+      - name: Analyze
+        run: cmake --build build/${{ matrix.preset }} --target tidy
       - name: Generate LCOV report
         if: ${{ matrix.preset == 'codecov' }}
         run: lcov -c -d . -o coverage.info --no-external --exclude "*/build/**"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.22)
 project(rsl VERSION 0.1.1 LANGUAGES CXX DESCRIPTION "ROS Support Library")
 
+set(CMAKE_CXX_EXTENSIONS OFF)
+
 find_package(ament_cmake REQUIRED)
 find_package(Eigen3 REQUIRED)
 find_package(tcb_span REQUIRED)
@@ -53,3 +55,5 @@ ament_export_dependencies(
     tl_expected
 )
 ament_package()
+
+add_custom_target(tidy COMMAND run-clang-tidy -p ${CMAKE_BINARY_DIR})

--- a/include/rsl/static_string.hpp
+++ b/include/rsl/static_string.hpp
@@ -15,8 +15,8 @@ namespace rsl {
  */
 template <size_t capacity>
 class StaticString {
-    std::array<std::string::value_type, capacity> data_;
-    size_t size_;
+    std::array<std::string::value_type, capacity> data_{};
+    size_t size_{};
 
    public:
     /**

--- a/include/rsl/static_vector.hpp
+++ b/include/rsl/static_vector.hpp
@@ -16,8 +16,8 @@ namespace rsl {
  */
 template <typename T, size_t capacity>
 class StaticVector {
-    std::array<T, capacity> data_;
-    size_t size_;
+    std::array<T, capacity> data_{};
+    size_t size_{};
 
    public:
     /**

--- a/package.xml
+++ b/package.xml
@@ -20,6 +20,7 @@
   <depend>tcb_span</depend>
   <depend>tl_expected</depend>
 
+  <test_depend>clang-tidy</test_depend>
   <test_depend>range-v3</test_depend>
 
   <export>

--- a/tests/monad.cpp
+++ b/tests/monad.cpp
@@ -204,16 +204,16 @@ TEST_CASE("rsl::has_value") {
 }
 
 TEST_CASE("operator|") {
-    auto const I = [](auto x) { return x; };
-    auto const K = [](auto x) { return [=](auto) { return x; }; };
+    auto const i = [](auto x) { return x; };
+    auto const k = [](auto x) { return [=](auto) { return x; }; };
     auto const mul = [](auto x, auto y) { return x * y; };
     auto const bind1 = [](auto fn, auto x) { return [=](auto y) { return fn(x, y); }; };
     auto const three = [](auto) { return int{3}; };
     auto const wrap = [](auto x) { return Result<decltype(x)>{x}; };
 
-    CHECK((int{5} | I) == 5);
-    CHECK((int{5} | I | K(3)) == 3);
-    CHECK(((int{7} | I | K)(3)) == 7);
+    CHECK((int{5} | i) == 5);
+    CHECK((int{5} | i | k(3)) == 3);
+    CHECK(((int{7} | i | k)(3)) == 7);
     CHECK((int{4} | bind1(mul, 3)) == 12);
     CHECK((double{5} | three) == 3);
     CHECK((double{5} | wrap).value() == Catch::Approx(5));

--- a/tests/overload.cpp
+++ b/tests/overload.cpp
@@ -5,7 +5,7 @@
 #include <variant>
 
 TEST_CASE("rsl::Overload") {
-    enum class Type { INT, FLOAT, STRING } type;
+    enum class Type { INT, FLOAT, STRING } type = Type::INT;
     auto const overload =
         rsl::Overload{[&type](int) { type = Type::INT; }, [&type](float) { type = Type::FLOAT; },
                       [&type](std::string const&) { type = Type::STRING; }};

--- a/tests/queue.cpp
+++ b/tests/queue.cpp
@@ -13,6 +13,8 @@ static_assert(!std::is_copy_assignable_v<rsl::Queue<int>>);
 static_assert(!std::is_nothrow_move_constructible_v<rsl::Queue<int>>);
 static_assert(!std::is_nothrow_move_assignable_v<rsl::Queue<int>>);
 
+// NOLINTBEGIN(readability-container-size-empty)
+
 TEST_CASE("rsl::Queue") {
     SECTION("Default constructor") {
         auto const queue = rsl::Queue<int>();
@@ -88,3 +90,5 @@ TEST_CASE("rsl::Queue") {
         }
     }
 }
+
+// NOLINTEND(readability-container-size-empty)


### PR DESCRIPTION
I had to explicitly disable compiler extensions because that forces CMake to emit the `-std=` flag which clang-tidy needs to know what version of C++ GCC is using. Otherwise clang-tidy can't know what C++ version is being used since it doesn't understand how to get the default language standard for GCC. If clang-tidy doesn't know what C++ version is being used then it emits false warnings about missing headers and other nonsense like that. Hopefully I can find a better way to work around this but for now it's a hack we need.

Closes #49 