### PR TITLE
Fix uninitialized class members

### DIFF
--- a/include/rsl/static_string.hpp
+++ b/include/rsl/static_string.hpp
@@ -15,8 +15,8 @@ namespace rsl {
  */
 template <size_t capacity>
 class StaticString {
-    std::array<std::string::value_type, capacity> data_;
-    size_t size_;
+    std::array<std::string::value_type, capacity> data_{};
+    size_t size_{};
 
    public:
     /**

--- a/include/rsl/static_vector.hpp
+++ b/include/rsl/static_vector.hpp
@@ -16,8 +16,8 @@ namespace rsl {
  */
 template <typename T, size_t capacity>
 class StaticVector {
-    std::array<T, capacity> data_;
-    size_t size_;
+    std::array<T, capacity> data_{};
+    size_t size_{};
 
    public:
     /**


### PR DESCRIPTION
The default constructors left all array elements and the size uninitialized.

This was caught by the cppcoreguidelines-pro-type-member-init clang-tidy check that I'm trying to get added in #54. I'm unsure how the tests didn't catch this since we do test the default constructor to the extent we can.