### PR TITLE
Always use position independent code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,8 @@ target_link_libraries(rsl PUBLIC
     tcb_span::tcb_span
     tl_expected::tl_expected
 )
+# Workaround for the fact that RSL is shipped as a static library without PIC enabled
+set_target_properties(rsl PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
 add_subdirectory(docs)
 


### PR DESCRIPTION
RSL v0.1.1 was shipped in ros-humble-rsl as a static library without position independent code enabled which caused issues with downstream shared libraries that linked to it. This works around that issue while we expore more permanent fixes