### PR TITLE
Type of library is SHARED

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,9 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "(GNU|Clang)")
     add_compile_options(-Werror -Wall -Wextra -Wpedantic -Wshadow -Wconversion -Wsign-conversion -Wold-style-cast)
 endif()
 
+# Default to shared libraries to work around the Debian ecosystem's inability to specify -DBUILD_SHARED_LIBS=ON at configuration :(
+option(BUILD_SHARED_LIBS "Build shared libraries" ON)
+
 add_library(rsl
     src/random.cpp
 )
@@ -26,8 +29,6 @@ target_link_libraries(rsl PUBLIC
     tcb_span::tcb_span
     tl_expected::tl_expected
 )
-# Workaround for the fact that RSL is shipped as a static library without PIC enabled
-set_target_properties(rsl PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
 add_subdirectory(docs)
 


### PR DESCRIPTION
It is a standard in Debian to package libraries as shared libraries and
only optionally provide a static library.
Reference:
https://www.debian.org/doc/debian-policy/ch-sharedlibs.html#static-libraries

The reasons for building as a SHARED library by default are:
- Shared libraries can be updated without rebuilding all packages that
  depend on them.
- Shared libraries can be used as dependencies to other shared
  libraries (fPIC is enabled by default on SHARED libraries).
- Shared libraries result in smaller installs because the code from each
  library is not copied into each binary.

The disadvantage of shared libraries is that the compiler is restricted
from making certain types of optimizations, such as inlining.
Note that these sorts of optimizations only apply to code that is
actually in the library and not provided by a header.
In our case, the only functions that are included in the library are:
- rng
- random_unit_quaternion

The STL is typically linked as a shared library, and the special case is
using it as a static library.
If some user has the requirement to use RSL as a static library, I think
it is reasonable that they would fork it and change the way it is built or
provide a PR to make it build as both a static and shared library.
