### PR TITLE
Implement `rsl::rng()` with `std::optional`

### DIFF
--- a/src/random.cpp
+++ b/src/random.cpp
@@ -8,9 +8,12 @@
 namespace rsl {
 
 auto rng(std::seed_seq seed_sequence) -> std::mt19937& {
-    thread_local auto first = true;
+    thread_local auto is_seeded = false;
+    if (is_seeded && seed_sequence.size() > 0)
+        throw std::runtime_error("rng cannot be re-seeded on this thread");
+
     thread_local auto generator = [&seed_sequence]() {
-        first = false;
+        is_seeded = true;
         if (seed_sequence.size() > 0) return std::mt19937(seed_sequence);
         auto seed_data = std::array<int, std::mt19937::state_size>();
         auto random_device = std::random_device();
@@ -19,8 +22,6 @@ auto rng(std::seed_seq seed_sequence) -> std::mt19937& {
         return std::mt19937(sequence);
     }();
 
-    if (!first && seed_sequence.size() > 0)
-        throw std::runtime_error("rng cannot be re-seeded on this thread");
     return generator;
 }
 

--- a/tests/random.cpp
+++ b/tests/random.cpp
@@ -2,12 +2,13 @@
 
 #include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
 
 #include <thread>
 
-TEST_CASE("rsl::rng") {
-    auto* const rng = &rsl::rng();
+static auto const* const rng = &rsl::rng({0, 1});
 
+TEST_CASE("rsl::rng") {
     SECTION("Repeated calls in thread yield same object") {
         CHECK(rng == &rsl::rng());
         CHECK(rng == &rsl::rng());
@@ -15,12 +16,20 @@ TEST_CASE("rsl::rng") {
     }
 
     SECTION("Calls from separate threads yield separate objects") {
-        std::thread([rng]() { CHECK(rng != &rsl::rng()); }).join();
+        // Test using randomly generated seed
+        auto thread1 = std::thread([] { CHECK(rng != &rsl::rng()); });
+
+        // Test that custom seed in separate thread does not throw
+        auto thread2 = std::thread([] { CHECK(rng != &rsl::rng({2, 3})); });
+
+        thread1.join();
+        thread2.join();
     }
 
     SECTION("Throw if seeded after first call") {
         CHECK_NOTHROW(rsl::rng({}));
-        CHECK_THROWS(rsl::rng({1, 2, 3, 4}));
+        CHECK_THROWS_WITH(rsl::rng({1, 2, 3, 4}), Catch::Matchers::ContainsSubstring(
+                                                      "rng cannot be re-seeded on this thread"));
     }
 }
 


### PR DESCRIPTION
I think this is a more expressive and readable alternative to the status quo. That `first` variable was never all that intuitive to me.