### PR TITLE
Change version of range-v3 to allow building on Ubuntu Focal

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,7 +1,7 @@
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 
 find_package(Catch2 3.2.0 REQUIRED)
-find_package(range-v3 0.11.0 REQUIRED)
+find_package(range-v3 0.10.0 REQUIRED)
 
 add_executable(test-rsl
     algorithm.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,7 +1,7 @@
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 
 find_package(Catch2 3.2.0 REQUIRED)
-find_package(range-v3 0.10.0 REQUIRED)
+find_package(range-v3 REQUIRED)
 
 add_executable(test-rsl
     algorithm.cpp


### PR DESCRIPTION
Do we absolutely need version 0.11.0? Does 0.10.0 work as well? This prevents this package to be build for Humble on Ubuntu Focal (which should be [supported](https://docs.ros.org/en/humble/Installation/Alternatives/Ubuntu-Development-Setup.html#:~:text=Tier%203%3A%20Ubuntu%20Linux%20%2D%20Focal%20(20.04)%2064%2Dbit))
https://packages.ubuntu.com/source/focal/range-v3

```
--- stderr: rsl                         
CMake Error at tests/CMakeLists.txt:4 (find_package):
  Could not find a configuration file for package "range-v3" that is
  compatible with requested version "0.11.0".

  The following configuration files were considered but not accepted:

    /usr/lib/cmake/range-v3/range-v3-config.cmake, version: 0.10.0
    /lib/cmake/range-v3/range-v3-config.cmake, version: 0.10.0



---
Failed   <<< rsl [4.65s, exited with code 1]

```