### PR TITLE
Use constructors over factory functions when possible

### DIFF
--- a/include/rsl/monad.hpp
+++ b/include/rsl/monad.hpp
@@ -44,7 +44,7 @@ template <typename T, typename E, typename Fn>
 [[nodiscard]] constexpr auto mbind(tl::expected<T, E> const& exp, Fn fn)
     -> std::invoke_result_t<Fn, T> {
     if (exp) return fn(exp.value());
-    return tl::make_unexpected(exp.error());
+    return tl::unexpected(exp.error());
 }
 
 /**
@@ -61,7 +61,7 @@ template <typename Fn>
 [[nodiscard]] auto mtry(Fn fn) -> tl::expected<std::invoke_result_t<Fn>, std::exception_ptr> try {
     return fn();
 } catch (...) {
-    return tl::make_unexpected(std::current_exception());
+    return tl::unexpected(std::current_exception());
 }
 
 /**

--- a/include/rsl/parameter_validators.hpp
+++ b/include/rsl/parameter_validators.hpp
@@ -26,13 +26,13 @@ template <typename T, typename Fn>
     switch (parameter.get_type()) {
         case rclcpp::ParameterType::PARAMETER_STRING:
             if (auto value = parameter.get_value<std::string>(); !predicate(value.size(), size))
-                return tl::make_unexpected(fmt::format(format_string, parameter.get_name(),
-                                                       value.size(), predicate_description, size));
+                return tl::unexpected(fmt::format(format_string, parameter.get_name(), value.size(),
+                                                  predicate_description, size));
             break;
         default:
             if (auto value = parameter.get_value<std::vector<T>>(); !predicate(value.size(), size))
-                return tl::make_unexpected(fmt::format(format_string, parameter.get_name(),
-                                                       value.size(), predicate_description, size));
+                return tl::unexpected(fmt::format(format_string, parameter.get_name(), value.size(),
+                                                  predicate_description, size));
     }
     return {};
 }
@@ -42,9 +42,9 @@ template <typename T, typename Fn>
                            std::string const& predicate_description, Fn const& predicate)
     -> tl::expected<void, std::string> {
     if (auto const param_value = parameter.get_value<T>(); !predicate(param_value, value))
-        return tl::make_unexpected(fmt::format("Parameter '{}' with the value {} must be {} {}",
-                                               parameter.get_name(), param_value,
-                                               predicate_description, value));
+        return tl::unexpected(fmt::format("Parameter '{}' with the value {} must be {} {}",
+                                          parameter.get_name(), param_value, predicate_description,
+                                          value));
     return {};
 }
 }  // namespace detail
@@ -61,7 +61,7 @@ template <typename T, typename Fn>
 template <typename T>
 [[nodiscard]] auto unique(rclcpp::Parameter const& parameter) -> tl::expected<void, std::string> {
     if (is_unique(parameter.get_value<std::vector<T>>())) return {};
-    return tl::make_unexpected(
+    return tl::unexpected(
         fmt::format("Parameter '{}' must only contain unique values", parameter.get_name()));
 }
 
@@ -77,7 +77,7 @@ template <typename T>
     auto const& values = parameter.get_value<std::vector<T>>();
     for (auto const& value : values)
         if (!contains(valid_values, value))
-            return tl::make_unexpected(
+            return tl::unexpected(
                 fmt::format("Entry '{}' in parameter '{}' is not in the set {{{}}}", value,
                             parameter.get_name(), fmt::join(valid_values, ", ")));
     return {};
@@ -129,12 +129,12 @@ template <typename T>
     switch (parameter.get_type()) {
         case rclcpp::ParameterType::PARAMETER_STRING:
             if (auto param_value = parameter.get_value<std::string>(); param_value.empty())
-                return tl::make_unexpected(
+                return tl::unexpected(
                     fmt::format("Parameter '{}' cannot be empty", parameter.get_name()));
             break;
         default:
             if (auto param_value = parameter.get_value<std::vector<T>>(); param_value.empty())
-                return tl::make_unexpected(
+                return tl::unexpected(
                     fmt::format("Parameter '{}' cannot be empty", parameter.get_name()));
     }
     return {};
@@ -152,7 +152,7 @@ template <typename T>
     auto const& param_value = parameter.get_value<std::vector<T>>();
     for (auto val : param_value)
         if (val < lower || val > upper)
-            return tl::make_unexpected(
+            return tl::unexpected(
                 fmt::format("Value {} in parameter '{}' must be within bounds [{}, {}]", val,
                             parameter.get_name(), lower, upper));
     return {};
@@ -170,7 +170,7 @@ template <typename T>
     auto const& param_value = parameter.get_value<std::vector<T>>();
     for (auto val : param_value)
         if (val < lower)
-            return tl::make_unexpected(
+            return tl::unexpected(
                 fmt::format("Value {} in parameter '{}' must be above lower bound of {}", val,
                             parameter.get_name(), lower));
     return {};
@@ -188,7 +188,7 @@ template <typename T>
     auto const& param_value = parameter.get_value<std::vector<T>>();
     for (auto val : param_value)
         if (val > upper)
-            return tl::make_unexpected(
+            return tl::unexpected(
                 fmt::format("Value {} in parameter '{}' must be below upper bound of {}", val,
                             parameter.get_name(), upper));
     return {};
@@ -205,7 +205,7 @@ template <typename T>
     -> tl::expected<void, std::string> {
     auto const& param_value = parameter.get_value<T>();
     if (param_value < lower || param_value > upper)
-        return tl::make_unexpected(
+        return tl::unexpected(
             fmt::format("Parameter '{}' with the value {} must be within bounds [{}, {}]",
                         parameter.get_name(), param_value, lower, upper));
     return {};
@@ -288,9 +288,9 @@ template <typename T>
     -> tl::expected<void, std::string> {
     auto const& param_value = parameter.get_value<T>();
     if (contains(collection, param_value)) return {};
-    return tl::make_unexpected(fmt::format(
-        "Parameter '{}' with the value {} is not in the set {{{}}}", parameter.get_name(),
-        param_value, fmt::format("{}", fmt::join(collection, ", "))));
+    return tl::unexpected(fmt::format("Parameter '{}' with the value {} is not in the set {{{}}}",
+                                      parameter.get_name(), param_value,
+                                      fmt::format("{}", fmt::join(collection, ", "))));
 }
 
 /**

--- a/include/rsl/try.hpp
+++ b/include/rsl/try.hpp
@@ -30,6 +30,6 @@
 #define TRY(expected)                                                              \
     ({                                                                             \
         auto const& _expected = (expected); /* Uglify name to prevent shadowing */ \
-        if (!_expected.has_value()) return tl::make_unexpected(_expected.error()); \
+        if (!_expected.has_value()) return tl::unexpected(_expected.error());      \
         _expected.value();                                                         \
     })

--- a/tests/monad.cpp
+++ b/tests/monad.cpp
@@ -7,8 +7,10 @@
 #include <cmath>
 #include <string>
 
+using namespace std::string_literals;
+
 static constexpr auto maybe_non_zero(int in) {
-    return (in != 0) ? std::make_optional(in) : std::nullopt;
+    return (in != 0) ? std::optional(in) : std::nullopt;
 }
 
 static auto maybe_lt_3_round(double in) {
@@ -24,7 +26,7 @@ template <typename T>
 using Result = tl::expected<T, std::string>;
 
 static Result<double> divide(double x, double y) {
-    if (y == 0) return tl::make_unexpected("divide by 0");
+    if (y == 0) return tl::unexpected("divide by 0"s);
     return x / y;
 }
 
@@ -37,7 +39,7 @@ static Result<double> multiply_3(double x) { return multiply(3, x); }
 TEST_CASE("rsl::mbind") {
     SECTION("Optional value") {
         // GIVEN optional value 4
-        constexpr auto opt = std::make_optional(4);
+        constexpr auto opt = std::optional(4);
 
         // WHEN we rsl::mbind it with the function maybe_non_zero
         // THEN we expect it true
@@ -46,7 +48,7 @@ TEST_CASE("rsl::mbind") {
 
     SECTION("Overloaded optional value") {
         // GIVEN optional value -4.0
-        constexpr auto opt = std::make_optional(-4.0);
+        constexpr auto opt = std::optional(-4.0);
 
         // WHEN we rsl::mbind it with two functions chained with operator| overload
         // THEN we expect it true
@@ -64,7 +66,7 @@ TEST_CASE("rsl::mbind") {
 
     SECTION("Optional no value output") {
         // GIVEN optional value with 0.0
-        constexpr auto opt = std::make_optional(0);
+        constexpr auto opt = std::optional(0);
 
         // WHEN we rsl::mbind it with the function maybe_non_zero
         // THEN we expect it false
@@ -91,7 +93,7 @@ TEST_CASE("rsl::mbind") {
 
     SECTION("Compose two") {
         // GIVEN the functions maybe_non_zero and maybe_lt_3_round and an input opt
-        constexpr auto opt = std::make_optional(-4.0);
+        constexpr auto opt = std::optional(-4.0);
 
         // WHEN we compose them together and then bind them with an input
         auto const compose_fn = rsl::mcompose(maybe_lt_3_round, maybe_non_zero);
@@ -105,7 +107,7 @@ TEST_CASE("rsl::mbind") {
 
     SECTION("Compose three") {
         // GIVEN the functions maybe_non_zero and maybe_lt_3_round and an input opt
-        auto const opt = std::make_optional(-4.0);
+        auto const opt = std::optional(-4.0);
 
         // WHEN we compose them together multiple times and then bind them with an input
         auto const compose_result =
@@ -118,7 +120,7 @@ TEST_CASE("rsl::mbind") {
     }
 
     SECTION("Pass unexpected value through bind") {
-        Result<double> const input = tl::make_unexpected("foo");
+        Result<double> const input = tl::unexpected("foo"s);
         auto const result = rsl::mbind(input, multiply_3);
         REQUIRE(rsl::has_error(result));
         CHECK(result.error() == "foo");
@@ -151,7 +153,7 @@ TEST_CASE("rsl::mbind") {
             auto const out = static_cast<int>(in);
             auto const check = static_cast<double>(out);
             if (check != in) {
-                return tl::make_unexpected("no worky casty");
+                return tl::unexpected("no worky casty"s);
             }
             return out;
         };
@@ -162,7 +164,7 @@ TEST_CASE("rsl::mbind") {
 TEST_CASE("rsl::has_error") {
     SECTION("Error") {
         // GIVEN expected type containing error
-        auto const exp = tl::expected<int, double>(tl::make_unexpected(0.1));
+        auto const exp = tl::expected<int, double>(tl::unexpected(0.1));
 
         // WHEN calling rsl::has_value and tl::expected::has_value
         // THEN we expect rsl::has_value is true, and tl::expected::has_value is false
@@ -184,7 +186,7 @@ TEST_CASE("rsl::has_error") {
 TEST_CASE("rsl::has_value") {
     SECTION("Error") {
         // GIVEN expected type containing error
-        auto const exp = tl::expected<int, double>(tl::make_unexpected(0.1));
+        auto const exp = tl::expected<int, double>(tl::unexpected(0.1));
 
         // WHEN calling rsl::has_value and tl::expected::has_value
         // THEN we expect has_error is false, and has_value is false

--- a/tests/parameter_validators.cpp
+++ b/tests/parameter_validators.cpp
@@ -389,7 +389,7 @@ TEST_CASE("rsl::to_parameter_result_msg") {
     }
 
     SECTION("Has error") {
-        auto const parameter_result = rsl::to_parameter_result_msg(tl::make_unexpected("test"));
+        auto const parameter_result = rsl::to_parameter_result_msg(tl::unexpected("test"s));
         CHECK(!parameter_result.successful);
         CHECK(parameter_result.reason == "test");
     }


### PR DESCRIPTION
There are seemingly some places where the factory functions are needed but in most instances we don't need them so I'm erring on the side of using constructors which involve fewer layer of indirection to understand.