### PR TITLE
Depend on ament_cmake_ros to default SHARED to ON

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ project(rsl VERSION 0.2.1 LANGUAGES CXX DESCRIPTION "ROS Support Library")
 
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-find_package(ament_cmake REQUIRED)
+find_package(ament_cmake_ros REQUIRED)
 find_package(Eigen3 REQUIRED)
 find_package(fmt REQUIRED)
 find_package(rclcpp REQUIRED)
@@ -13,9 +13,6 @@ find_package(tl_expected REQUIRED)
 if(CMAKE_CXX_COMPILER_ID MATCHES "(GNU|Clang)")
     add_compile_options(-Werror -Wall -Wextra -Wpedantic -Wshadow -Wconversion -Wsign-conversion -Wold-style-cast)
 endif()
-
-# Default to shared libraries to work around the Debian ecosystem's inability to specify -DBUILD_SHARED_LIBS=ON at configuration :(
-option(BUILD_SHARED_LIBS "Build shared libraries" ON)
 
 add_library(rsl
     src/parameter_validators.cpp

--- a/package.xml
+++ b/package.xml
@@ -12,7 +12,7 @@
   <maintainer email="chrisjthrasher@gmail.com">Chris Thrasher</maintainer>
   <license>BSD-3-Clause</license>
 
-  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_ros</buildtool_depend>
   <buildtool_depend>doxygen</buildtool_depend>
   <buildtool_depend>git</buildtool_depend>
 


### PR DESCRIPTION
This adds my latest learnings about why we need to set BUILD_SHARED_LIBS on for ROS packages. We are using the tooling built by the ROS 2 team here get this change in behavior. An explanation as to why this was done was added to the commit message.