### PR TITLE
Deprecate `rsl::lower_bounds` and `rsl::upper_bounds`

### DIFF
--- a/include/rsl/parameter_validators.hpp
+++ b/include/rsl/parameter_validators.hpp
@@ -218,7 +218,8 @@ template <typename T>
  * @return Help string if the parameter is invalid, otherwise void
  */
 template <typename T>
-[[nodiscard]] auto lower_bounds(rclcpp::Parameter const& parameter, T const& value) {
+[[deprecated("Replace with rsl::gt_eq"), nodiscard]] auto lower_bounds(
+    rclcpp::Parameter const& parameter, T const& value) {
     return detail::compare(parameter, value, "above lower bound of", std::greater_equal<T>());
 }
 
@@ -229,7 +230,8 @@ template <typename T>
  * @return Help string if the parameter is invalid, otherwise void
  */
 template <typename T>
-[[nodiscard]] auto upper_bounds(rclcpp::Parameter const& parameter, T const& value) {
+[[deprecated("Replace with rsl::lt_eq"), nodiscard]] auto upper_bounds(
+    rclcpp::Parameter const& parameter, T const& value) {
     return detail::compare(parameter, value, "below upper bound of", std::less_equal<T>());
 }
 

--- a/tests/parameter_validators.cpp
+++ b/tests/parameter_validators.cpp
@@ -247,42 +247,6 @@ TEST_CASE("rsl::bounds") {
     CHECK(result.error() == "Parameter 'test' with the value -4.3 must be within bounds [1, 5]");
 }
 
-TEST_CASE("rsl::lower_bounds") {
-    CHECK(rsl::lower_bounds<double>(Parameter("", 2.0), 2.0));
-    CHECK(rsl::lower_bounds<double>(Parameter("", 4.3), 1.0));
-    CHECK(!rsl::lower_bounds<double>(Parameter("", -4.3), 1.0));
-
-    CHECK(rsl::lower_bounds<int64_t>(Parameter("", 1), 1));
-    CHECK(rsl::lower_bounds<int64_t>(Parameter("", 4), 1));
-    CHECK(!rsl::lower_bounds<int64_t>(Parameter("", -4), 1));
-
-    CHECK(rsl::lower_bounds<bool>(Parameter("", true), false));
-    CHECK(!rsl::lower_bounds<bool>(Parameter("", false), true));
-    CHECK(rsl::lower_bounds<bool>(Parameter("", true), true));
-
-    auto const result = rsl::lower_bounds<double>(Parameter("test", -4.3), 1.0);
-    REQUIRE(!result);
-    CHECK(result.error() == "Parameter 'test' with the value -4.3 must be above lower bound of 1");
-}
-
-TEST_CASE("rsl::upper_bounds") {
-    CHECK(rsl::upper_bounds<double>(Parameter("", 2.0), 2.0));
-    CHECK(!rsl::upper_bounds<double>(Parameter("", 4.3), 1.0));
-    CHECK(rsl::upper_bounds<double>(Parameter("", -4.3), 1.0));
-
-    CHECK(rsl::upper_bounds<int64_t>(Parameter("", 1), 1));
-    CHECK(!rsl::upper_bounds<int64_t>(Parameter("", 4), 1));
-    CHECK(rsl::upper_bounds<int64_t>(Parameter("", -4), 1));
-
-    CHECK(!rsl::upper_bounds<bool>(Parameter("", true), false));
-    CHECK(rsl::upper_bounds<bool>(Parameter("", false), true));
-    CHECK(rsl::upper_bounds<bool>(Parameter("", true), true));
-
-    auto const result = rsl::upper_bounds<double>(Parameter("test", 4.3), 1.0);
-    REQUIRE(!result);
-    CHECK(result.error() == "Parameter 'test' with the value 4.3 must be below upper bound of 1");
-}
-
 TEST_CASE("rsl::lt") {
     CHECK(!rsl::lt<double>(Parameter("", 2.0), 2.0));
     CHECK(!rsl::lt<double>(Parameter("", 4.3), 1.0));


### PR DESCRIPTION
Closes #62 