### PR TITLE
Update Catch2 to version 3.3.2

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,6 +1,6 @@
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 
-find_package(Catch2 3.3.0 REQUIRED)
+find_package(Catch2 3.3.2 REQUIRED)
 find_package(range-v3 REQUIRED)
 
 add_executable(test-rsl


### PR DESCRIPTION
Reduced allocations and improved performance
Section tracking is 10%-25% faster than in v3.3.0
Assertion handling is 5%-10% faster than in v3.3.0
Test case registration is 1%-2% faster than in v3.3.0
