### PR TITLE
Use correct type for seed values

### DIFF
--- a/src/random.cpp
+++ b/src/random.cpp
@@ -22,7 +22,7 @@ auto rng(std::seed_seq seed_sequence) -> std::mt19937& {
     if (seed_sequence.size() > 0) return generator.emplace(seed_sequence);
 
     // Seed with randomized sequence
-    auto seed_data = std::array<int, std::mt19937::state_size>();
+    auto seed_data = std::array<std::random_device::result_type, std::mt19937::state_size>();
     auto random_device = std::random_device();
     std::generate_n(seed_data.data(), seed_data.size(), std::ref(random_device));
     auto sequence = std::seed_seq(seed_data.begin(), seed_data.end());


### PR DESCRIPTION
https://en.cppreference.com/w/cpp/numeric/random/random_device

This type is actually an `unsigned int` not an `int`.