### PR TITLE
Enable function cognitive complexity check

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -17,7 +17,6 @@ Checks: >
   -modernize-avoid-bind,
   -modernize-use-trailing-return-type,
   -readability-braces-around-statements,
-  -readability-function-cognitive-complexity,
   -readability-identifier-length,
   -readability-magic-numbers,
   -readability-uppercase-literal-suffix,
@@ -32,5 +31,8 @@ CheckOptions:
   - { key: readability-identifier-naming.MemberCase,          value: lower_case }
   - { key: readability-identifier-naming.PrivateMemberCase,   value: lower_case }
   - { key: readability-identifier-naming.PrivateMemberSuffix, value: _ }
+  - { key: readability-function-cognitive-complexity.Threshold,               value: 15   }
+  - { key: readability-function-cognitive-complexity.DescribeBasicIncrements, value: True }
+  - { key: readability-function-cognitive-complexity.IgnoreMacros,            value: True }
 HeaderFilterRegex: '.*'
 WarningsAsErrors: '*'


### PR DESCRIPTION
Our worst offending functions have a score of 5 which is basically nothing. I picked 15 as our limit because that is what SonarCloud uses and it's a nice, low number that we ought to never exceed for a library of this scale.