### PR TITLE
Mark git as a test dependency

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -14,7 +14,6 @@
 
   <buildtool_depend>ament_cmake_ros</buildtool_depend>
   <buildtool_depend>doxygen</buildtool_depend>
-  <buildtool_depend>git</buildtool_depend>
 
   <depend>eigen</depend>
   <depend>fmt</depend>
@@ -23,6 +22,7 @@
   <depend>tl_expected</depend>
 
   <test_depend>clang-tidy</test_depend>
+  <test_depend>git</test_depend>
   <test_depend>range-v3</test_depend>
 
   <export>


### PR DESCRIPTION
Git is only needed to build the tests (because it's used to clone Catch2) so it's more accurate to call it a test dependency.