### PR TITLE
Add `rsl::StrongType`

### DIFF
--- a/include/rsl/strong_type.hpp
+++ b/include/rsl/strong_type.hpp
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <utility>
+
+namespace rsl {
+
+/** @file */
+
+/**
+ * @brief Class template for creating strong type aliases
+ *
+ * @tparam T value type
+ * @tparam Tag Tag type to disambiguate separate type aliases
+ */
+template <typename T, typename Tag>
+class StrongType {
+    T value_;
+
+   public:
+    /**
+     * @brief Construct from any type
+     */
+    constexpr explicit StrongType(T value) : value_(std::move(value)) {}
+
+    /**
+     * @brief Get non-const reference to underlying value
+     */
+    [[nodiscard]] constexpr T& get() { return value_; }
+
+    /**
+     * @brief Get const reference to underlying value
+     */
+    [[nodiscard]] constexpr const T& get() const { return value_; }
+
+    /**
+     * @brief Explicit conversion to underlying type
+     */
+    [[nodiscard]] constexpr explicit operator T() const { return value_; }
+};
+
+}  // namespace rsl

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -14,6 +14,7 @@ add_executable(test-rsl
     random.cpp
     static_string.cpp
     static_vector.cpp
+    strong_type.cpp
     try.cpp)
 target_link_libraries(test-rsl PRIVATE
     rsl::rsl

--- a/tests/strong_type.cpp
+++ b/tests/strong_type.cpp
@@ -1,0 +1,27 @@
+#include <rsl/strong_type.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+
+TEST_CASE("rsl::StrongType") {
+    using StrongInt = rsl::StrongType<int, struct StrongIntTag>;  // For testing constexpr support
+    using StrongString =
+        rsl::StrongType<std::string, struct StringStringTag>;  // For testing non-constexpr types
+
+    SECTION("Construction") {
+        constexpr auto strong_int = StrongInt(42);
+        STATIC_CHECK(strong_int.get() == 42);
+        STATIC_CHECK(int{strong_int} == 42);
+        STATIC_CHECK(int(strong_int) == 42);
+
+        auto const strong_string = StrongString("abcdefg");
+        CHECK(strong_string.get() == "abcdefg");
+        CHECK(std::string{strong_string} == "abcdefg");
+        CHECK(std::string(strong_string) == "abcdefg");
+    }
+
+    SECTION("get()") {
+        auto strong_int = StrongInt(1337);
+        strong_int.get() = 100;
+        CHECK(strong_int.get() == 100);
+    }
+}


### PR DESCRIPTION
Strong type aliases are a useful pattern but they require just enough boilerplate that you don't typically see codebases implement them and they're just small and non-specific enough that libraries don't provide them. This type aims to fill that gap so that we can actually use strong type aliases in our code.

Motivating example:

```cpp
using JointID = rsl::StrongType<std::uint64_t, struct JointIDTag>;

struct Joint {
    JointID id;
    int count;
};

auto joint = Joint{JointID(4), 2};
auto joint = Joint{2, JointID(4)}; // Won't compile
```

The presence of a strong type alias ensures that the order of arguments is correct. Without that strong alias, it would be easy to accidentally swap the two arguments without realizing it.
