### PR TITLE
Remove ament macros

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,6 @@ project(rsl VERSION 0.2.1 LANGUAGES CXX DESCRIPTION "ROS Support Library")
 
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-find_package(ament_cmake_ros REQUIRED)
 find_package(Eigen3 REQUIRED)
 find_package(fmt REQUIRED)
 find_package(rclcpp REQUIRED)
@@ -14,16 +13,15 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "(GNU|Clang)")
     add_compile_options(-Werror -Wall -Wextra -Wpedantic -Wshadow -Wconversion -Wsign-conversion -Wold-style-cast)
 endif()
 
+option(BUILD_SHARED_LIBS "Build shared libraries" ON)
+
 add_library(rsl
     src/parameter_validators.cpp
     src/random.cpp
 )
 add_library(rsl::rsl ALIAS rsl)
 target_compile_features(rsl PUBLIC cxx_std_17)
-target_include_directories(rsl PUBLIC
-    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
-    $<INSTALL_INTERFACE:include/rsl>
-)
+target_include_directories(rsl PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>)
 target_link_libraries(rsl PUBLIC
     Eigen3::Eigen
     fmt::fmt
@@ -43,22 +41,20 @@ install(
     DESTINATION include/rsl
 )
 install(
-    TARGETS rsl
-    EXPORT export_rsl
+    TARGETS rsl EXPORT rsl-targets
     ARCHIVE DESTINATION lib
     LIBRARY DESTINATION lib
     RUNTIME DESTINATION bin
-    INCLUDES DESTINATION include
+    INCLUDES DESTINATION include/rsl
 )
-
-ament_export_targets(export_rsl HAS_LIBRARY_TARGET)
-ament_export_dependencies(
-    Eigen3
-    fmt
-    rclcpp
-    tcb_span
-    tl_expected
+install(
+    EXPORT rsl-targets
+    NAMESPACE rsl::
+    DESTINATION share/rsl/cmake
 )
-ament_package()
+install(
+    FILES cmake/rsl-config.cmake
+    DESTINATION share/rsl/cmake
+)
 
 add_custom_target(tidy COMMAND run-clang-tidy -p ${CMAKE_BINARY_DIR})

--- a/cmake/rsl-config.cmake
+++ b/cmake/rsl-config.cmake
@@ -1,0 +1,7 @@
+find_dependency(Eigen3)
+find_dependency(fmt)
+find_dependency(rclcpp)
+find_dependency(tcb_span)
+find_dependency(tl_expected)
+
+include(${CMAKE_CURRENT_LIST_DIR}/rsl-targets.cmake)

--- a/package.xml
+++ b/package.xml
@@ -12,7 +12,6 @@
   <maintainer email="chrisjthrasher@gmail.com">Chris Thrasher</maintainer>
   <license>BSD-3-Clause</license>
 
-  <buildtool_depend>ament_cmake_ros</buildtool_depend>
   <buildtool_depend>doxygen</buildtool_depend>
 
   <depend>eigen</depend>
@@ -24,8 +23,4 @@
   <test_depend>clang-tidy</test_depend>
   <test_depend>git</test_depend>
   <test_depend>range-v3</test_depend>
-
-  <export>
-    <build_type>ament_cmake</build_type>
-  </export>
 </package>


### PR DESCRIPTION
This is an experiment to determine whether we can build ROS packages that don't use ament. As far as we can tell, Ament is not strictly necessary but rather exists to provide some conveniences related to installing Cmake projects. Because we know how to install libraries using vanilla CMake, we can write that code ourselves rather than add a new dependency.