### PR TITLE
Revert "Remove ament macros"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@ project(rsl VERSION 1.0.0 LANGUAGES CXX DESCRIPTION "ROS Support Library")
 
 set(CMAKE_CXX_EXTENSIONS OFF)
 
+find_package(ament_cmake_ros REQUIRED)
 find_package(Eigen3 REQUIRED)
 find_package(fmt REQUIRED)
 find_package(rclcpp REQUIRED)
@@ -12,8 +13,6 @@ find_package(tl_expected REQUIRED)
 if(CMAKE_CXX_COMPILER_ID MATCHES "(GNU|Clang)")
     add_compile_options(-Werror -Wall -Wextra -Wpedantic -Wshadow -Wconversion -Wsign-conversion -Wold-style-cast)
 endif()
-
-option(BUILD_SHARED_LIBS "Build shared libraries" ON)
 
 add_library(rsl
     src/parameter_validators.cpp
@@ -49,15 +48,15 @@ install(
     RUNTIME DESTINATION bin
     INCLUDES DESTINATION include/rsl
 )
-install(
-    EXPORT rsl-targets
-    NAMESPACE rsl::
-    DESTINATION share/rsl/cmake
+
+ament_export_targets(rsl-targets HAS_LIBRARY_TARGET)
+ament_export_dependencies(
+    Eigen3
+    fmt
+    rclcpp
+    tcb_span
+    tl_expected
 )
-write_basic_package_version_file(rsl-config-version.cmake COMPATIBILITY SameMajorVersion)
-install(
-    FILES cmake/rsl-config.cmake ${PROJECT_BINARY_DIR}/rsl-config-version.cmake
-    DESTINATION share/rsl/cmake
-)
+ament_package()
 
 add_custom_target(tidy COMMAND run-clang-tidy -p ${CMAKE_BINARY_DIR})

--- a/cmake/rsl-config.cmake
+++ b/cmake/rsl-config.cmake
@@ -1,9 +1,0 @@
-include(CMakeFindDependencyMacro)
-
-find_dependency(Eigen3)
-find_dependency(fmt)
-find_dependency(rclcpp)
-find_dependency(tcb_span)
-find_dependency(tl_expected)
-
-include(${CMAKE_CURRENT_LIST_DIR}/rsl-targets.cmake)

--- a/package.xml
+++ b/package.xml
@@ -12,6 +12,7 @@
   <maintainer email="chrisjthrasher@gmail.com">Chris Thrasher</maintainer>
   <license>BSD-3-Clause</license>
 
+  <buildtool_depend>ament_cmake_ros</buildtool_depend>
   <buildtool_depend>doxygen</buildtool_depend>
 
   <depend>eigen</depend>
@@ -23,4 +24,8 @@
   <test_depend>clang-tidy</test_depend>
   <test_depend>git</test_depend>
   <test_depend>range-v3</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
 </package>


### PR DESCRIPTION
This reverts commit 7cb590ab83df29880b9b39a63281fc72757d569f.

Here I come back tucking my tail between my legs. We wrote install interface tests and even did some manual testing with this new RSL version in the wild using projects that depend on RSL. We found no issues so we felt comfortable shipping. Alas something about the Debian packaging of RSL results in an `rsl::rsl` target which seemingly lacks the correct interface install directories or interface link libraries resulting in numerous build failures.

We're unsure why this is the case or why any of this is happening or whether adding `ament` back will even fix anything.