### PR TITLE
Add more messages for assertion failures

### DIFF
--- a/include/rsl/random.hpp
+++ b/include/rsl/random.hpp
@@ -36,8 +36,8 @@ auto rng(std::seed_seq seed_sequence = {}) -> std::mt19937&;
  */
 template <typename RealType>
 [[nodiscard]] auto uniform_real(RealType lower, RealType upper) {
-    static_assert(std::is_floating_point_v<RealType>);
-    assert(lower < upper);
+    static_assert(std::is_floating_point_v<RealType>, "RealType must be a floating point type");
+    assert(lower < upper && "rsl::uniform_real: Lower bound be less than upper bound");
     return std::uniform_real_distribution(lower, upper)(rng());
 }
 
@@ -53,8 +53,9 @@ template <typename RealType>
  */
 template <typename IntType>
 [[nodiscard]] auto uniform_int(IntType lower, IntType upper) {
-    static_assert(std::is_integral_v<IntType>);
-    assert(lower <= upper);
+    static_assert(std::is_integral_v<IntType>, "IntType must be an integral type");
+    assert(lower <= upper &&
+           "rsl::uniform_int: Lower bound must be less than or equal to upper bound");
     return std::uniform_int_distribution(lower, upper)(rng());
 }
 

--- a/include/rsl/static_string.hpp
+++ b/include/rsl/static_string.hpp
@@ -28,7 +28,8 @@ class StaticString {
      * @brief Construct from a std::string
      */
     StaticString(std::string const& string) : size_(std::min(string.size(), capacity)) {
-        assert(string.size() <= capacity);
+        assert(string.size() <= capacity &&
+               "rsl::StaticString::StaticString: Input exceeds capacity");
         std::copy(string.cbegin(), string.cbegin() + std::string::difference_type(size_),
                   data_.begin());
     }

--- a/include/rsl/static_vector.hpp
+++ b/include/rsl/static_vector.hpp
@@ -30,7 +30,8 @@ class StaticVector {
      */
     template <typename Collection>
     StaticVector(Collection const& collection) : size_(std::min(collection.size(), capacity)) {
-        assert(collection.size() <= capacity);
+        assert(collection.size() <= capacity &&
+               "rsl::StaticVector::StaticVector: Input exceeds capacity");
         std::copy(collection.cbegin(),
                   collection.cbegin() + typename Collection::difference_type(size_), data_.begin());
     }


### PR DESCRIPTION
It's very user friendly to provide some explanation for why a compiletime or runtime assertion failed.