### PR TITLE
Disable tests by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,8 @@ target_link_libraries(rsl PUBLIC
 
 add_subdirectory(docs)
 
-if(BUILD_TESTING)
+option(RSL_BUILD_TESTING "Build tests" OFF)
+if(RSL_BUILD_TESTING)
     add_subdirectory(tests)
 endif()
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -17,7 +17,8 @@
                 "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
                 "CMAKE_EXE_LINKER_FLAGS": "-fuse-ld=lld",
                 "CMAKE_MODULE_LINKER_FLAGS": "-fuse-ld=lld",
-                "CMAKE_SHARED_LINKER_FLAGS": "-fuse-ld=lld"
+                "CMAKE_SHARED_LINKER_FLAGS": "-fuse-ld=lld",
+                "RSL_BUILD_TESTING": "ON"
             },
             "warnings": {
                 "unusedCli": false


### PR DESCRIPTION
Those who build RSL from source in their workspace do not need to build our tests. Let's disable them by default. The default build ought to be as minimal as possible as to prevent unnecessary build failures as seen in #103.