### PR TITLE
Test consuming RSL via `ament_target_dependencies`

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -20,6 +20,7 @@
   <depend>tcb_span</depend>
   <depend>tl_expected</depend>
 
+  <test_depend>ament_cmake_ros</test_depend>
   <test_depend>clang-tidy</test_depend>
   <test_depend>git</test_depend>
   <test_depend>range-v3</test_depend>

--- a/tests/install/CMakeLists.txt
+++ b/tests/install/CMakeLists.txt
@@ -2,8 +2,14 @@ cmake_minimum_required(VERSION 3.22)
 project(rsl-install-test)
 
 if(PROJECT_IS_TOP_LEVEL)
+    # Test consumption via find_package interface and ament_target_dependencies
+    find_package(ament_cmake_ros REQUIRED)
     find_package(rsl 1.1.0 EXACT REQUIRED)
-endif()
 
-add_executable(test-rsl-install install.cpp)
-target_link_libraries(test-rsl-install PRIVATE rsl::rsl)
+    add_executable(test-rsl-install install.cpp)
+    ament_target_dependencies(test-rsl-install rsl)
+else()
+    # Test consumption via in-tree build
+    add_executable(test-rsl-install install.cpp)
+    target_link_libraries(test-rsl-install PRIVATE rsl::rsl)
+endif()


### PR DESCRIPTION
These tests should give us a lot more confidence for now and in the future that we maintain support with `ament_target_dependencies` users.