### PR TITLE
Add support for compilation and test on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,13 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "(GNU|Clang)")
     add_compile_options(-Werror -Wall -Wextra -Wpedantic -Wshadow -Wconversion -Wsign-conversion -Wold-style-cast)
 endif()
 
+if(MSVC)
+    # On Windows, also ensure that all .dll libraries are placed in the
+    # same build directory so they can be found by the loader (there is
+    # no rpath on Windows)
+    set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_BINDIR}")
+endif()
+
 option(BUILD_SHARED_LIBS "Build shared libraries" ON)
 
 add_library(rsl
@@ -29,6 +36,17 @@ target_link_libraries(rsl PUBLIC
     tcb_span::tcb_span
     tl_expected::tl_expected
 )
+
+# There is no explicit export of symbols in the library either via
+# hand-written ***_export.h headers or generate_export_header CMake macro,
+# as the header-only functions in this library are quite limited in number,
+# it is perfectly ok to export all of them (as done in *nix) with the
+# WINDOWS_EXPORT_ALL_SYMBOLS property
+if(MSVC)
+    set_target_properties(rsl PROPERTIES
+        WINDOWS_EXPORT_ALL_SYMBOLS TRUE
+    )
+endif()
 
 add_subdirectory(docs)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -14,8 +14,10 @@ add_executable(test-rsl
     random.cpp
     static_string.cpp
     static_vector.cpp
-    strong_type.cpp
-    try.cpp)
+    strong_type.cpp)
+if(NOT MSVC)
+  target_sources(test-rsl PRIVATE try.cpp)
+endif()
 target_link_libraries(test-rsl PRIVATE
     rsl::rsl
     Catch2::Catch2WithMain

--- a/tests/static_string.cpp
+++ b/tests/static_string.cpp
@@ -20,9 +20,10 @@ TEST_CASE("rsl::StaticString") {
 
         SECTION("Collection constructor") {
             auto const string = "Hello, world!"s;
-            auto const static_string = rsl::StaticString<14>(string);
+            constexpr int string_capacity = 14;
+            auto const static_string = rsl::StaticString<string_capacity>(string);
             CHECK(static_string.begin() != static_string.end());
-            auto const* begin = static_string.begin();
+            std::array<std::string::value_type, string_capacity>::const_iterator begin = static_string.begin();
             CHECK(*begin++ == 'H');
             CHECK(*begin++ == 'e');
             CHECK(*begin++ == 'l');


### PR DESCRIPTION
I tested this on Visual Studio 2022.

The modifications are mainly three:
* 1. Use `WINDOWS_EXPORT_ALL_SYMBOLS` to export automatically all defined functions. This ensures that `rsl.lib` is actually created, before this change only the `rsl.dll` library was created resulting in downstream errors such as the one reported in https://github.com/RoboStack/ros-humble/issues/136#issuecomment-1935500512
* 2. Set `CMAKE_RUNTIME_OUTPUT_DIRECTORY` so all the compiled .dll and .exe are placed in the same folder, ensuring that the `test-rsl.exe` can find `Catch2.dll` , `Catch2Main.dll` and `rsl.dll`
* 3. I excluded `try.cpp` files from the tests on Windows as they were not compiling on Windows
* 4. I modified the test in `static_string.cpp` to avoid requiring an implicit conversion from an iterator to a pointer