### PR TITLE
Disable compiler warnings by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,8 @@ find_package(rclcpp REQUIRED)
 find_package(tcb_span REQUIRED)
 find_package(tl_expected REQUIRED)
 
-if(CMAKE_CXX_COMPILER_ID MATCHES "(GNU|Clang)")
+option(RSL_ENABLE_WARNINGS "Enable compiler warnings" OFF)
+if(RSL_ENABLE_WARNINGS AND CMAKE_CXX_COMPILER_ID MATCHES "(GNU|Clang)")
     add_compile_options(-Werror -Wall -Wextra -Wpedantic -Wshadow -Wconversion -Wsign-conversion -Wold-style-cast)
 endif()
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -18,7 +18,8 @@
                 "CMAKE_EXE_LINKER_FLAGS": "-fuse-ld=lld",
                 "CMAKE_MODULE_LINKER_FLAGS": "-fuse-ld=lld",
                 "CMAKE_SHARED_LINKER_FLAGS": "-fuse-ld=lld",
-                "RSL_BUILD_TESTING": "ON"
+                "RSL_BUILD_TESTING": "ON",
+                "RSL_ENABLE_WARNINGS": "ON"
             },
             "warnings": {
                 "unusedCli": false


### PR DESCRIPTION
Unconditionally enabling `-Werror` is a heavy-handed approach and not ideal when shipping code to be used by many third parties. In fact it's even better to disable warnings by default since compiler warnings are not hard requirements. They're merely a development tool that developers should opt into.

Closes #117
