### PR TITLE
Disable `TRY` macro tests on MSVC

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -14,8 +14,10 @@ add_executable(test-rsl
     random.cpp
     static_string.cpp
     static_vector.cpp
-    strong_type.cpp
-    try.cpp)
+    strong_type.cpp)
+if(CMAKE_CXX_COMPILER_ID MATCHES "(GNU|Clang)")
+    target_sources(test-rsl PRIVATE try.cpp) # Requires GCC extensions
+endif()
 target_link_libraries(test-rsl PRIVATE
     rsl::rsl
     Catch2::Catch2WithMain


### PR DESCRIPTION
The `TRY` macro requires a GCC/Clang extension so we need to make sure we only compile those tests when GCC or Clang is being used.

Addresses part of but not all #116.