### PR TITLE
Fix static_string.cpp compilation with MSVC standard library

### DIFF
--- a/tests/static_string.cpp
+++ b/tests/static_string.cpp
@@ -22,7 +22,7 @@ TEST_CASE("rsl::StaticString") {
             auto const string = "Hello, world!"s;
             auto const static_string = rsl::StaticString<14>(string);
             CHECK(static_string.begin() != static_string.end());
-            auto const* begin = static_string.begin();
+            auto begin = static_string.begin();  // NOLINT(readability-qualified-auto)
             CHECK(*begin++ == 'H');
             CHECK(*begin++ == 'e');
             CHECK(*begin++ == 'l');


### PR DESCRIPTION
`std::array`'s iterator is a pointer in libc++ and libstdc++ so `const auto*` works fine. However the array iterator is not a pointer on MSVC so compilation fails. Removing the asterisk still results in a pointer type being used but causes a clang-tidy check to fail so we have to disable that.