### PR TITLE
Hide symbols from shared libraries by default and support DLL creation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,13 +16,17 @@ endif()
 
 option(BUILD_SHARED_LIBS "Build shared libraries" ON)
 
+include(GenerateExportHeader)
 add_library(rsl
     src/parameter_validators.cpp
     src/random.cpp
 )
 add_library(rsl::rsl ALIAS rsl)
 target_compile_features(rsl PUBLIC cxx_std_17)
-target_include_directories(rsl PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>)
+target_include_directories(rsl PUBLIC
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+    $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>
+)
 target_link_libraries(rsl PUBLIC
     Eigen3::Eigen
     fmt::fmt
@@ -30,6 +34,8 @@ target_link_libraries(rsl PUBLIC
     tcb_span::tcb_span
     tl_expected::tl_expected
 )
+set_target_properties(rsl PROPERTIES CXX_VISIBILITY_PRESET hidden VISIBILITY_INLINES_HIDDEN YES)
+generate_export_header(rsl EXPORT_FILE_NAME include/rsl/export.hpp)
 
 add_subdirectory(docs)
 
@@ -41,7 +47,7 @@ endif()
 include(CMakePackageConfigHelpers)
 
 install(
-    DIRECTORY include/
+    DIRECTORY include/ ${PROJECT_BINARY_DIR}/include/
     DESTINATION include/rsl
 )
 install(

--- a/include/rsl/parameter_validators.hpp
+++ b/include/rsl/parameter_validators.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <rsl/algorithm.hpp>
+#include <rsl/export.hpp>
 #include <rsl/static_string.hpp>
 #include <rsl/static_vector.hpp>
 
@@ -298,7 +299,7 @@ template <typename T>
 /**
  * @brief Convert the result of a validator function into a SetParametersResult msg
  */
-[[nodiscard]] auto to_parameter_result_msg(tl::expected<void, std::string> const& result)
+[[nodiscard]] RSL_EXPORT auto to_parameter_result_msg(tl::expected<void, std::string> const& result)
     -> rcl_interfaces::msg::SetParametersResult;
 
 }  // namespace rsl

--- a/include/rsl/random.hpp
+++ b/include/rsl/random.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <rsl/export.hpp>
+
 #include <Eigen/Geometry>
 #include <cassert>
 #include <random>
@@ -22,7 +24,7 @@ namespace rsl {
  *
  * @return Seeded random number generator
  */
-auto rng(std::seed_seq seed_sequence = {}) -> std::mt19937&;
+RSL_EXPORT auto rng(std::seed_seq seed_sequence = {}) -> std::mt19937&;
 
 /**
  * @brief Get a uniform real number in a given range
@@ -63,6 +65,6 @@ template <typename IntType>
  * @brief Generate a random unit quaternion of doubles
  * @return Random unit quaternion
  */
-[[nodiscard]] auto random_unit_quaternion() -> Eigen::Quaterniond;
+[[nodiscard]] RSL_EXPORT auto random_unit_quaternion() -> Eigen::Quaterniond;
 
 }  // namespace rsl


### PR DESCRIPTION
https://gcc.gnu.org/wiki/Visibility

Hiding symbols by default from shared libraries has benefits you can read about above. Along with doing this we also ensure that DLLs are supported on Windows and thus make sure we provide 1st class support to all uses irrespective of their platform of choice.