### PR TITLE
Ensure FindEigen3.cmake is not used

### DIFF
--- a/cmake/rsl-config.cmake
+++ b/cmake/rsl-config.cmake
@@ -1,6 +1,6 @@
 include(CMakeFindDependencyMacro)
 
-find_dependency(Eigen3)
+find_dependency(Eigen3 CONFIG)
 find_dependency(fmt)
 find_dependency(rclcpp)
 find_dependency(tcb_span)


### PR DESCRIPTION
Oversight from #125 since we don't test the install interface on RHEL.