### PR TITLE
Fix clang-tidy errors

### DIFF
--- a/include/rsl/algorithm.hpp
+++ b/include/rsl/algorithm.hpp
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef RSL_ALGORITHM_HPP
+#define RSL_ALGORITHM_HPP
 
 #include <algorithm>
 
@@ -40,3 +41,5 @@ template <typename Collection>
 }
 
 }  // namespace rsl
+
+#endif  // RSL_ALGORITHM_HPP

--- a/include/rsl/monad.hpp
+++ b/include/rsl/monad.hpp
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef RSL_MONAD_HPP
+#define RSL_MONAD_HPP
 
 #include <tl/expected.hpp>
 
@@ -165,6 +166,7 @@ constexpr inline bool is_optional = is_optional_impl<std::remove_cv_t<std::remov
  *
  * @return Return type of f
  */
+// NOLINTBEGIN(modernize-use-constraints): RSL is documented as a C++17 library.
 template <typename T, typename Fn, typename = std::enable_if_t<rsl::is_optional<T>>,
           typename = std::enable_if_t<std::is_invocable_v<
               Fn, typename std::remove_cv_t<std::remove_reference_t<T>>::value_type>>>
@@ -205,3 +207,6 @@ template <typename T, typename Fn, typename = std::enable_if_t<!rsl::is_optional
     typename std::enable_if_t<std::is_invocable_v<Fn, T>, std::invoke_result_t<Fn, T>> {
     return std::invoke(std::forward<Fn>(fn), std::forward<T>(val));
 }
+// NOLINTEND(modernize-use-constraints)
+
+#endif  // RSL_MONAD_HPP

--- a/include/rsl/no_discard.hpp
+++ b/include/rsl/no_discard.hpp
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef RSL_NO_DISCARD_HPP
+#define RSL_NO_DISCARD_HPP
 
 #include <utility>
 
@@ -26,3 +27,5 @@ class NoDiscard {
 };
 
 }  // namespace rsl
+
+#endif  // RSL_NO_DISCARD_HPP

--- a/include/rsl/overload.hpp
+++ b/include/rsl/overload.hpp
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef RSL_OVERLOAD_HPP
+#define RSL_OVERLOAD_HPP
 
 namespace rsl {
 
@@ -18,3 +19,5 @@ template <class... Ts>
 Overload(Ts...) -> Overload<Ts...>;
 
 }  // namespace rsl
+
+#endif  // RSL_OVERLOAD_HPP

--- a/include/rsl/parameter_validators.hpp
+++ b/include/rsl/parameter_validators.hpp
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef RSL_PARAMETER_VALIDATORS_HPP
+#define RSL_PARAMETER_VALIDATORS_HPP
 
 #include <rsl/algorithm.hpp>
 #include <rsl/export.hpp>
@@ -320,3 +321,5 @@ template <typename T>
     -> rcl_interfaces::msg::SetParametersResult;
 
 }  // namespace rsl
+
+#endif  // RSL_PARAMETER_VALIDATORS_HPP

--- a/include/rsl/queue.hpp
+++ b/include/rsl/queue.hpp
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef RSL_QUEUE_HPP
+#define RSL_QUEUE_HPP
 
 #include <chrono>
 #include <condition_variable>
@@ -26,7 +27,7 @@ class Queue {
      * @return Queue size
      */
     [[nodiscard]] auto size() const noexcept {
-        auto const lock = std::lock_guard(mutex_);
+        auto const lock = std::scoped_lock(mutex_);
         return queue_.size();
     }
 
@@ -35,7 +36,7 @@ class Queue {
      * @return True if the queue is empty, otherwise false
      */
     [[nodiscard]] auto empty() const noexcept {
-        auto const lock = std::lock_guard(mutex_);
+        auto const lock = std::scoped_lock(mutex_);
         return queue_.empty();
     }
 
@@ -44,7 +45,7 @@ class Queue {
      * @param value Data to push into the queue
      */
     void push(T value) noexcept {
-        auto const lock = std::lock_guard(mutex_);
+        auto const lock = std::scoped_lock(mutex_);
         queue_.push(std::move(value));
         cv_.notify_one();
     }
@@ -53,7 +54,7 @@ class Queue {
      * @brief Clear the queue
      */
     void clear() noexcept {
-        auto const lock = std::lock_guard(mutex_);
+        auto const lock = std::scoped_lock(mutex_);
 
         // Swap queue with an empty queue of the same type to ensure queue_ is left in a
         // default-constructed state
@@ -77,3 +78,5 @@ class Queue {
     }
 };
 }  // namespace rsl
+
+#endif  // RSL_QUEUE_HPP

--- a/include/rsl/random.hpp
+++ b/include/rsl/random.hpp
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef RSL_RANDOM_HPP
+#define RSL_RANDOM_HPP
 
 #include <rsl/export.hpp>
 
@@ -68,3 +69,5 @@ template <typename IntType>
 [[nodiscard]] RSL_EXPORT auto random_unit_quaternion() -> Eigen::Quaterniond;
 
 }  // namespace rsl
+
+#endif  // RSL_RANDOM_HPP

--- a/include/rsl/static_string.hpp
+++ b/include/rsl/static_string.hpp
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef RSL_STATIC_STRING_HPP
+#define RSL_STATIC_STRING_HPP
 
 #include <array>
 #include <cassert>
@@ -58,3 +59,5 @@ template <size_t capacity>
 }
 
 }  // namespace rsl
+
+#endif  // RSL_STATIC_STRING_HPP

--- a/include/rsl/static_vector.hpp
+++ b/include/rsl/static_vector.hpp
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef RSL_STATIC_VECTOR_HPP
+#define RSL_STATIC_VECTOR_HPP
 
 #include <tcb_span/span.hpp>
 
@@ -82,3 +83,5 @@ template <typename T, size_t capacity>
 }
 
 }  // namespace rsl
+
+#endif  // RSL_STATIC_VECTOR_HPP

--- a/include/rsl/strong_type.hpp
+++ b/include/rsl/strong_type.hpp
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef RSL_STRONG_TYPE_HPP
+#define RSL_STRONG_TYPE_HPP
 
 #include <utility>
 
@@ -39,3 +40,5 @@ class StrongType {
 };
 
 }  // namespace rsl
+
+#endif  // RSL_STRONG_TYPE_HPP

--- a/include/rsl/try.hpp
+++ b/include/rsl/try.hpp
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef RSL_TRY_HPP
+#define RSL_TRY_HPP
 
 #include <tl/expected.hpp>
 
@@ -33,3 +34,5 @@
         if (!_expected.has_value()) return tl::unexpected(_expected.error());      \
         _expected.value();                                                         \
     })
+
+#endif  // RSL_TRY_HPP

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -30,6 +30,7 @@ auto rng(std::seed_seq seed_sequence) -> std::mt19937& {
 }
 
 auto random_unit_quaternion() -> Eigen::Quaterniond {
+    // NOLINTNEXTLINE(modernize-use-std-numbers): RSL is documented as a C++17 library.
     static constexpr auto pi = 3.1415926535897932385;
 
     // From "Uniform Random Rotations", Ken Shoemake, Graphics Gems III, pg. 124-132

--- a/tests/queue.cpp
+++ b/tests/queue.cpp
@@ -89,7 +89,7 @@ TEST_CASE("rsl::Queue") {
             for (auto& producer : producers) producer.join();
             for (auto& consumer : consumers) consumer.join();
 
-            CHECK(queue.size() == thread_count * item_count - items_removed);
+            CHECK(queue.size() == (thread_count * item_count) - items_removed);
         }
     }
 }


### PR DESCRIPTION
## Summary

- replaces `#pragma once` with include guards in the public RSL headers flagged by clang-tidy
- switches `Queue`'s simple mutex guards to `std::scoped_lock`
- parenthesizes the queue size assertion flagged by `readability-math-missing-parentheses`
- keeps the existing C++17 contract by locally suppressing the C++20-only `modernize-use-constraints` and `modernize-use-std-numbers` suggestions with comments

Fixes #168.

## Validation

- `pre-commit run --files include/rsl/algorithm.hpp include/rsl/monad.hpp include/rsl/no_discard.hpp include/rsl/overload.hpp include/rsl/parameter_validators.hpp include/rsl/queue.hpp include/rsl/random.hpp include/rsl/static_string.hpp include/rsl/static_vector.hpp include/rsl/strong_type.hpp include/rsl/try.hpp src/random.cpp tests/queue.cpp`
- `git diff --check`
- `c++ -std=c++17 -Iinclude -fsyntax-only -x c++-header include/rsl/queue.hpp`
- `c++ -std=c++17 -Iinclude -fsyntax-only -x c++-header include/rsl/algorithm.hpp`
- `c++ -std=c++17 -Iinclude -fsyntax-only -x c++-header include/rsl/no_discard.hpp`

I could not run the full CMake/ROS test matrix locally on macOS: the repo preset assumes Linux `lld`, and a local CMake configure without that preset stops on missing ROS/Eigen dependencies. The GitHub Actions matrix should cover the full ROS/clang-tidy path.
